### PR TITLE
fixup type compatibility checking for map, function types

### DIFF
--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -3874,12 +3874,35 @@ UNIT_TEST(formula_types_compatible) {
 UNIT_TEST(formula_function_types_compatible) {
 	CHECK_EQ(Formula(variant("types_compatible('function(string) ->int', 'function(string) ->any')")).execute().as_bool(), false);
 	CHECK_EQ(Formula(variant("types_compatible('function(string) ->any', 'function(string) ->int')")).execute().as_bool(), true);
-	CHECK_EQ(Formula(variant("types_compatible('function(string) ->int', 'function(any) ->int')")).execute().as_bool(), false);
-	CHECK_EQ(Formula(variant("types_compatible('function(any) ->int', 'function(string) ->int')")).execute().as_bool(), true);
+	CHECK_EQ(Formula(variant("types_compatible('function(string) ->int', 'function(any) ->int')")).execute().as_bool(), true);
+	CHECK_EQ(Formula(variant("types_compatible('function(any) ->int', 'function(string) ->int')")).execute().as_bool(), false);
 	CHECK_EQ(Formula(variant("types_compatible('function(string) ->int', 'function(any) ->any')")).execute().as_bool(), false);
-	CHECK_EQ(Formula(variant("types_compatible('function(any) ->any', 'function(string) ->int')")).execute().as_bool(), true);
+	CHECK_EQ(Formula(variant("types_compatible('function(any) ->any', 'function(string) ->int')")).execute().as_bool(), false);
 	CHECK_EQ(Formula(variant("types_compatible('function(any) ->int', 'function(string) ->any')")).execute().as_bool(), false);
-	CHECK_EQ(Formula(variant("types_compatible('function(string) ->any', 'function(any) ->int')")).execute().as_bool(), false);
+	CHECK_EQ(Formula(variant("types_compatible('function(string) ->any', 'function(any) ->int')")).execute().as_bool(), true);
+}
+
+UNIT_TEST(formula_map_types_compatible) {
+	CHECK_EQ(Formula(variant("types_compatible('{string -> int}', '{string -> any}')")).execute().as_bool(), false);
+	CHECK_EQ(Formula(variant("types_compatible('{string -> any}', '{string -> int}')")).execute().as_bool(), true);
+	CHECK_EQ(Formula(variant("types_compatible('{string -> int}', '{any -> int}')")).execute().as_bool(), true);
+	CHECK_EQ(Formula(variant("types_compatible('{any -> int}', '{string -> int}')")).execute().as_bool(), false);
+	CHECK_EQ(Formula(variant("types_compatible('{string -> int}', '{any -> any}')")).execute().as_bool(), false);
+	CHECK_EQ(Formula(variant("types_compatible('{any -> any}', '{string -> int}')")).execute().as_bool(), false);
+	CHECK_EQ(Formula(variant("types_compatible('{any -> int}', '{string -> any}')")).execute().as_bool(), false);
+	CHECK_EQ(Formula(variant("types_compatible('{string -> any}', '{any -> int}')")).execute().as_bool(), true);
+}
+
+UNIT_TEST(formula_multifunction_types_compatible) {
+	CHECK_EQ(Formula(variant("types_compatible('function(int,any) ->int', 'function(int,int) ->int')")).execute().as_bool(), false);
+	CHECK_EQ(Formula(variant("types_compatible('function(int,int) ->int', 'function(int,int) ->int')")).execute().as_bool(), true);
+	CHECK_EQ(Formula(variant("types_compatible('function(int,int) ->int', 'function(int,any) ->int')")).execute().as_bool(), true);
+	CHECK_EQ(Formula(variant("types_compatible('function(int,int) ->int', 'function(any,int) ->int')")).execute().as_bool(), true);
+	CHECK_EQ(Formula(variant("types_compatible('function(int,int) ->int', 'function(any,any) ->int')")).execute().as_bool(), true);
+	CHECK_EQ(Formula(variant("types_compatible('function(int,int) ->int', 'function(any,any) ->any')")).execute().as_bool(), false);
+	CHECK_EQ(Formula(variant("types_compatible('function(int,int) ->any', 'function(any,any) ->any')")).execute().as_bool(), true);
+	CHECK_EQ(Formula(variant("types_compatible('function(int,int) ->any', 'function(any,string) ->any')")).execute().as_bool(), false);
+	CHECK_EQ(Formula(variant("types_compatible('function(string,int) ->any', 'function(int,string) ->any')")).execute().as_bool(), false);
 }
 
 UNIT_TEST(formula_list_comprehension) {

--- a/src/variant_type.cpp
+++ b/src/variant_type.cpp
@@ -1151,7 +1151,10 @@ public:
 	bool is_compatible(variant_type_ptr type, std::ostringstream* why) const {
 		std::pair<variant_type_ptr,variant_type_ptr> p = type->is_map_of();
 		if(p.first && p.second) {
-			return variant_types_compatible(key_type_, p.first) &&
+			// The given type of map can be used as a map of this type if,
+			// a key to this type of map can be used as a key of that map,
+			// and a value resulting from that map can be returned as a value of this type of map.
+			return variant_types_compatible(p.first, key_type_) &&
 			       variant_types_compatible(value_type_, p.second);
 		}
 
@@ -1439,8 +1442,12 @@ public:
 				return false;
 			}
 
+			// Order is args[n], args_[n] here, and return_, return_type above,
+			// Because type argument can serve as an instance of this type if,
+			// the inputs to this can be used as arguments of type,
+			// and the result of type can be used as the return value of this.
 			for(int n = 0; n != args_.size(); ++n) {
-				if(!variant_types_compatible(args_[n], args[n])) {
+				if(!variant_types_compatible(args[n], args_[n])) {
 					return false;
 				}
 			}
@@ -2667,7 +2674,7 @@ UNIT_TEST(variant_type) {
 	TYPES_COMPAT("list", "[any]");
 	TYPES_COMPAT("[any]", "[int|string]");
 	TYPES_COMPAT("[any]", "list");
-	TYPES_COMPAT("{int|string -> string}", "{int -> string}");
+	TYPES_COMPAT("{int -> string}", "{int|string -> string}");
 	TYPES_COMPAT("map", "{int -> string}");
 
 	TYPES_COMPAT("[int]", "[int,int]");
@@ -2695,6 +2702,7 @@ UNIT_TEST(variant_type) {
 	TYPES_INCOMPAT("enum { 2, 3 }", "enum { 2, 3, 4 }");
 	TYPES_INCOMPAT("int|null", "enum { 2, 3, 4.5 }");
 	TYPES_INCOMPAT("enum { 2..8 }", "enum { 2, 3, 4..6, 9 }");
+	TYPES_INCOMPAT("{int|string -> string}", "{int -> string}");
 
 #undef TYPES_COMPAT	
 }


### PR DESCRIPTION
(Fixes up commit 49c7df18f8630013a842bd2524a829e11defb3ff)

Say type T_1 is compatible with type T_2 if T_2 can be substituted
for T_1. Notate this T_2 <= T_1.

For function and map types, we had defined type compatibility
by something like

(A->B) <= (C->D) iff (A <= C) and (B <= D),

where (A->B) denotes the function type which takes A and yields B.

But it should be

(A->B) <= (C->D) iff (C <= A) and (B <= D).

This is because if a function f is usable as type (C->D) it needs
to be the case that a C can be used as an argument for the function,
and that the result of the function can be returned as a D.

This commit changes the behavior for function types and map types,
and adds some unit tests. I believe that it works correctly for
overloaded functions via inheritance but I didn't add unit tests
for this.
