### PR TITLE
clean up some heap memory allocated at static initialization time

### DIFF
--- a/src/formula_function.cpp
+++ b/src/formula_function.cpp
@@ -4250,9 +4250,21 @@ std::map<std::string, variant>& get_doc_cache(bool prefs_dir) {
 
 		typedef std::map<std::string, FunctionCreator*> functions_map;
 
+		// Takes ownership of the pointers, deleting them at program termination to
+		// suppress valgrind false positives
+		struct functions_map_manager {
+			functions_map map_;
+			~functions_map_manager() {
+				for (auto & v : map_) {
+					delete(v.second);
+				}
+			}
+		};
+
 		functions_map& get_functions_map() {
 
-			static functions_map functions_table;
+			static functions_map_manager map_man;
+			functions_map & functions_table = map_man.map_;
 
 			if(functions_table.empty()) {
 		#define FUNCTION(name) functions_table[#name] = new SpecificFunctionCreator<name##_function>();

--- a/src/formula_function_registry.cpp
+++ b/src/formula_function_registry.cpp
@@ -25,17 +25,34 @@
 #include "formula_function_registry.hpp"
 #include "unit_test.hpp"
 
-namespace 
+namespace
 {
+	typedef std::map<std::string, std::map<std::string, FunctionCreator*> > function_creators_table;
+	typedef std::map<std::string, std::vector<std::string> > helpstrings_table;
+
+	// Takes ownership of the pointers in the function creator table,
+	// deleting them at program termination to suppress valgrind false positives.
+	struct function_creator_manager {
+		function_creators_table table_;
+
+		~function_creator_manager() {
+			for(function_creators_table::value_type & v : table_) {
+				for(auto u : v.second) {
+					delete(u.second);
+				}
+			}
+		}
+	};
+
 	std::map<std::string, std::map<std::string, FunctionCreator*> >& function_creators()
 	{
-		static std::map<std::string, std::map<std::string, FunctionCreator*> > instance;
-		return instance;
+		static function_creator_manager instance;
+		return instance.table_;
 	}
 
 	std::map<std::string, std::vector<std::string> >& helpstrings()
 	{
-		static std::map<std::string, std::vector<std::string> > instance;
+		static helpstrings_table instance;
 		return instance;
 	}
 }


### PR DESCRIPTION
After this commit, valgrind does not report any memory leaks
associated to any of the unit tests, except those associated to
FFL recursion:

formula_test_recurse_sort
formula_test_recursion
recursive_call_lambda

Edit: And these tests also report no leaks, if `--leak-check-heuristics=all` is passed.
