### PR TITLE
fix compilation with clang (by suppressing warnings in lib headers)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,10 +64,10 @@ BASE_CXXFLAGS += -std=c++0x -g -fno-inline-functions \
 LDFLAGS?=-rdynamic
 
 # Compiler include options, used after CXXFLAGS and CPPFLAGS.
-INC := -Iexternal/include $(shell pkg-config --cflags x11 sdl2 glew SDL2_image SDL2_ttf libpng zlib freetype2 cairo)
+INC := -isystem external/include $(shell pkg-config --cflags x11 sdl2 glew SDL2_image SDL2_ttf libpng zlib freetype2 cairo)
 
 ifdef STEAM_RUNTIME_ROOT
-	INC += -I$(STEAM_RUNTIME_ROOT)/include
+	INC += -isystem $(STEAM_RUNTIME_ROOT)/include
 endif
 
 # Linker library options.


### PR DESCRIPTION
Changes the makefile to include library headers using the -isystem
switch instead of -I switch. This is a gcc feature, and therefore
supported by clang also. It fixes some warnings found by clang 3.5
in boost headers.

Tested with g++ 4.9 and clang++ 3.5.

c.f.
[1] https://gcc.gnu.org/onlinedocs/cpp/System-Headers.html
[2] http://stackoverflow.com/questions/1867065/how-to-suppress-gcc-warnings-from-library-headers
