### PR TITLE
More type output on error (WIP)

### DIFF
--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -2813,6 +2813,15 @@ namespace game_logic
 			return result;
 		}
 
+static std::string debugSubexpressionTypes(ConstFormulaPtr & fml)
+{
+	std::stringstream ss;
+	for(auto & child : fml->expr()->queryChildrenRecursive()) {
+		ss << "Type " << child->queryVariantType()->to_string() << "\n";
+		ss << child->debugPinpointLocation(nullptr) << "\n\n";
+	}
+	return ss.str();
+}
 		//only returns a value in the case of a lambda function, otherwise
 		//returns nullptr.
 		ExpressionPtr parse_function_def(const variant& formula_str, const Token*& i1, const Token* i2, FunctionSymbolTable* symbols, ConstFormulaCallableDefinitionPtr callable_def)
@@ -3005,7 +3014,7 @@ namespace game_logic
 
 				if(g_strict_formula_checking) {
 					std::ostringstream why;
-					STRICT_ASSERT(!result_type || variant_types_compatible(result_type, fml->queryVariantType(), &why), "Formula function return type mis-match. Expects " << result_type->to_string() << " but expression evaluates to " << fml->queryVariantType()->to_string() << "\n" << pinpoint_location(formula_str, beg->begin, (i2-1)->end) << "\n" << why.str());
+					STRICT_ASSERT(!result_type || variant_types_compatible(result_type, fml->queryVariantType(), &why), "Formula function return type mis-match. Expects " << result_type->to_string() << " but expression evaluates to " << fml->queryVariantType()->to_string() << "\n" << pinpoint_location(formula_str, beg->begin, (i2-1)->end) << "\n" << why.str() << "\n\nSubexpressions:\n\n" << debugSubexpressionTypes(fml));
 				}
 
 				LambdaFunctionExpression* result = new LambdaFunctionExpression(args, fml, callable_def ? callable_def->getNumSlots() : 0, default_args, variant_types, result_type ? result_type : fml->queryVariantType());


### PR DESCRIPTION
One commit adds type output to callstacks of functions.
One commit adds type and pinpoint location output for _all subexpressions_ of an expression when function definitions fail. This kind of dump can sometimes help to quickly spot the problem when the type mismatch is caused by programmer confusion and not a typo.

It might be better if this was the behavior when a "verbose" flag is passed to anura or something. It also would be more useful if it were used in more places.

Sample output of the recursive type checking:

```
CRITICAL: formula.cpp:3017 ASSERTION FAILED: Formula function return type mis-match. Expects [class creature] but expression evaluates to [[class creature]]
At modules/Citadel/data/classes/creature.cfg 499:
map(targets_attacking(game), value.targets_attacking(game))
^



Subexpressions:

Type [[class creature]]
At modules/Citadel/data/classes/creature.cfg 499:
map(targets_attacking(game), value.targets_attacking(game))
^


Type [class creature]
At modules/Citadel/data/classes/creature.cfg 499:
map(targets_attacking(game), value.targets_attacking(game))
    ^----------------------^


Type function(class game) -> [class creature]
At modules/Citadel/data/classes/creature.cfg 499:
map(targets_attacking(game), value.targets_attacking(game))
    ^----------------^


Type class game
At modules/Citadel/data/classes/creature.cfg 499:
map(targets_attacking(game), value.targets_attacking(game))
                      ^---^


Type [class creature]
At modules/Citadel/data/classes/creature.cfg 499:
map(targets_attacking(game), value.targets_attacking(game))
                             ^----------------------------^


Type function(class game) -> [class creature]
At modules/Citadel/data/classes/creature.cfg 499:
map(targets_attacking(game), value.targets_attacking(game))
                             ^----------------------^


Type class creature
At modules/Citadel/data/classes/creature.cfg 499:
map(targets_attacking(game), value.targets_attacking(game))
                             ^----^


Type function(class game) -> [class creature]
At modules/Citadel/data/classes/creature.cfg 499:
map(targets_attacking(game), value.targets_attacking(game))
                                   ^----------------^


Type class game
At modules/Citadel/data/classes/creature.cfg 499:
...cking(game), value.targets_attacking(game))
                                        ^---^




CRITICAL: 

---
CRITICAL: stack trace:
CRITICAL:   ./anura : output_backtrace()+0x33
CRITICAL:   ./anura() [0xf48dd6]
CRITICAL:   ./anura() [0xf3e747]
CRITICAL:   ./anura() [0xf2f717]
CRITICAL:   ./anura : game_logic::Formula::Formula(variant const&, game_logic::FunctionSymbolTable*, boost::intrusive_ptr<game_logic::FormulaCallableDefinition const>)+0x977
CRITICAL:   ./anura : game_logic::Formula::createOptionalFormula(variant const&, game_logic::FunctionSymbolTable*, boost::intrusive_ptr<game_logic::FormulaCallableDefinition const>, game_logic::Formula::FORMULA_LANGUAGE)+0x96
CRITICAL:   ./anura() [0xfc6437]
CRITICAL:   ./anura : game_logic::FormulaClass::FormulaClass(std::string const&, variant const&)+0x5e0
CRITICAL:   ./anura() [0xfcc472]
CRITICAL:   ./anura() [0xfc5bd9]
CRITICAL:   ./anura : game_logic::FormulaObject::loadAllClasses()+0xc7
CRITICAL:   ./anura : main()+0x3e31
CRITICAL:   /lib/x86_64-linux-gnu/libc.so.6 : __libc_start_main()+0xf5
CRITICAL:   ./anura() [0xbc5012]
CRITICAL: ---
```
