### PR TITLE
I18n: add support to read multiple translations files, and to read po files

### DIFF
--- a/src/i18n.cpp
+++ b/src/i18n.cpp
@@ -1,6 +1,6 @@
 /*
 	Copyright (C) 2003-2014 by David White <davewx7@gmail.com>
-	
+
 	This software is provided 'as-is', without any express or implied
 	warranty. In no event will the authors be held liable for any damages
 	arising from the use of this software.
@@ -52,7 +52,7 @@
 #include <sstream>
 #endif
 
-namespace 
+namespace
 {
 	//header structure of the MO file format, as described on
 	//http://www.gnu.org/software/hello/manual/gettext/MO-Files.html
@@ -99,36 +99,135 @@ namespace
 			const std::string msgstr = content.substr(translated[i].offset, translated[i].length);
 
 			auto p = hashmap.insert(make_pair(msgid, msgstr));
-			if (p.second) {
+			if (!p.second && msgstr != p.first->second) {
 				LOG_DEBUG("i18n: Overwriting a translation of string \"" << msgid << "\":");
 				LOG_DEBUG("i18n: Changing \"" << p.first->second << "\" to \"" << msgstr << "\"");
 				p.first->second = msgstr;
 			}
 		}
 	}
+
+	// On input a string free of newline, expected to be wrapped in quotes,
+	// with possible leading or trailing whitespace, and escaped characters (?),
+	// this function should push to the stream the contents that were quoted,
+	// and ideally flag errors... and handle utf-8 appropriately...
+	void parse_quoted_string(std::stringstream & ss, const std::string & str) {
+		static std::string whitespace = " \t\n\r";
+
+		bool pre_string = true;
+		bool post_string = false;
+
+		for (std::string::const_iterator it = str.begin(); it != str.end(); it++) {
+			if (pre_string || post_string) {
+				if (*it == '\"') {
+					if (post_string) {
+						LOG_ERROR("i18n: Only one quoted string is allowed on a line of po file: \n<<" << str << ">>");
+						return;
+					}
+					pre_string = false;
+				} else if (whitespace.find(*it) == std::string::npos) {
+					LOG_ERROR("i18n: Unexpected characters in po file where only whitespace is expected: \'" << *it << "\':\n<<" << str << ">>");
+				}
+			} else {
+				if (*it == '\"') {
+					post_string = true;
+				} else if (*it == '\\') {
+					it++;
+					char c = *it;
+					switch (c) {
+						case 'n': {
+							ss << '\n';
+							break;
+						}
+						default:
+							ss << c;
+							break;
+					}
+				} else {
+					ss << *it;
+				}
+			}
+		}
+		if (!pre_string && !post_string) {
+			LOG_ERROR("i18n: unterminated quoted string in po file:\n<<" << str << ">>");
+		}
+	}
+
+	enum po_item { PO_NONE, PO_MSGID, PO_MSGSTR };
+
+	void process_po_contents(const std::string & content) {
+		std::stringstream ss;
+		ss.str(content);
+
+		std::stringstream msgid;
+		std::stringstream msgstr;
+
+		po_item current_item = PO_NONE;
+
+		for (std::string line; std::getline(ss, line); ) {
+			if (line.size() > 0 && line[0] != '#') {
+				if (line.size() > 6 && line.substr(0,6) == "msgid ") {
+					// This is the start of a new item, so store the previous item (if there was a previous item)
+					if (current_item != PO_NONE) {
+						std::string id = msgid.str(), str = msgstr.str();
+						auto p = hashmap.insert(make_pair(id, str));
+						if (str != p.first->second) {
+							LOG_DEBUG("i18n: Overwriting a translation of string \"" << id << "\":");
+							LOG_DEBUG("i18n: Changing \"" << p.first->second << "\" to \"" << str << "\"");
+							p.first->second = str;
+						}
+						msgid.str("");
+						msgstr.str("");
+					}
+					parse_quoted_string(msgid, line.substr(6));
+					current_item = PO_MSGID;
+				} else if (line.size() > 7 && line.substr(0,7) == "msgstr ") {
+					if (current_item == PO_NONE) {
+						LOG_ERROR("i18n: in po file, found a msgstr with no earlier msgid:\n<<" << line << ">>");
+					}
+
+					parse_quoted_string(msgstr, line.substr(7));
+					current_item = PO_MSGSTR;
+				} else {
+					switch (current_item) {
+						case PO_MSGID: {
+							parse_quoted_string(msgid, line);
+							break;
+						}
+						case PO_MSGSTR: {
+							parse_quoted_string(msgstr, line);
+							break;
+						}
+						default:
+							break;
+					}
+				}
+			}
+		}
+	}
 }
 
-namespace i18n 
+namespace i18n
 {
-	const std::string& tr(const std::string& msgid) 
+	const std::string& tr(const std::string& msgid)
 	{
 		//do not attempt to translate empty strings ("") since that returns metadata
 		if (msgid.empty())
 			return msgid;
-		map::iterator it = hashmap.find (msgid);
+		map::iterator it = hashmap.find (msgid); 
 		if (it != hashmap.end())
 			return it->second;
 		//if no translated string was found, return the original
 		return msgid;
 	}
 
-	const std::string& get_locale() 
+	const std::string& get_locale()
 	{
 		return locale;
 	}
 
 	// Feels like a hack
-	bool is_locale_cjk() 
+	bool is_locale_cjk()
 	{
 		if(locale.empty()) {
 			return false;
@@ -137,12 +236,12 @@ namespace i18n
 			return false;
 		}
 		ASSERT_LOG(locale.size() >= 2, "Length of local string too short: " << locale);
-		return (locale[0] == 'z'  && locale[1] == 'h') 
+		return (locale[0] == 'z'  && locale[1] == 'h')
 			|| (locale[0] == 'j'  && locale[1] == 'a')
 			|| (locale[0] == 'k'  && locale[1] == 'o');
 	}
 
-	void load_translations() 
+	void load_translations()
 	{
 		hashmap.clear();
 		//strip the charset part of the country and language code,
@@ -183,6 +282,10 @@ namespace i18n
 					LOG_DEBUG("loading translations from mo file: " << path);
 					process_mo_contents(sys::read_file(module::map_file(path)));
 					loaded_something = true;
+				} else if (extension == ".po") {
+					LOG_DEBUG("loading translations from po file: " << path);
+					process_po_contents(sys::read_file(module::map_file(path)));
+					loaded_something = true;
 				} else {
 					LOG_DEBUG("skipping translations file: " << path);
 				}
@@ -196,13 +299,13 @@ namespace i18n
 		}
 	}
 
-	void setLocale(const std::string& l) 
+	void setLocale(const std::string& l)
 	{
 		locale = l;
 		i18n::load_translations();
 	}
 
-	void use_system_locale() 
+	void use_system_locale()
 	{
 #ifdef _WIN32
 		{
@@ -215,7 +318,7 @@ namespace i18n
 			}
 		}
 #endif
-		
+
 #ifdef __APPLE__
 		CFArrayRef localeIDs = CFLocaleCopyPreferredLanguages();
 		if (localeIDs)
@@ -253,14 +356,14 @@ namespace i18n
 			if (cstr != nullptr)
 				locale = cstr;
 		}
-	
+
 		if (locale == "zh-Hans") locale = "zh_CN"; //hack to make it work on iOS
 		if (locale == "zh-Hant") locale = "zh_TW";
 #endif
-		i18n::load_translations(); 
+		i18n::load_translations();
 	}
 
-	void init() 
+	void init()
 	{
 		locale = preferences::locale();
 		if(locale == "system" || locale == "") {


### PR DESCRIPTION
This commit makes anura able to read po files just as well as mo files. Tested by using the frogatto po files, by playtesting, also loading the po and mo files for german simultaneously and checking for mismatches.

It doesn't fully parse the po format -- anura apparently doesn't make use of the "plural strings" syntax.

It is claimed here (http://pology.nedohodnik.net/doc/user/en_US/ch-poformat.html) that the po format is not fully specified.
Some description also appears here (https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html)
I am not sure atm what are all the characters that need to be escaped for instance.

We do not use "libgettext-po" (as described here: https://www.gnu.org/software/gettext/manual/html_node/libgettextpo.html#libgettextpo), because this library wants to open the file itself, and based on past experience with gettext, this means that it will fail to work properly on files with non-ascii characters in the path (when compiled with mingw). Also it creates a large external dependency.
