### PR TITLE
More i18n ii

### DIFF
--- a/src/i18n.cpp
+++ b/src/i18n.cpp
@@ -132,23 +132,17 @@ namespace
 		for (std::string::const_iterator it = str.begin(); it != str.end(); it++) {
 			if (pre_string || post_string) {
 				if (*it == '\"') {
-					if (post_string) {
-						LOG_ERROR("i18n: Only one quoted string is allowed on a line of po file: \n<<" << str << ">>");
-						return;
-					}
+					ASSERT_LOG(!post_string, "i18n: Only one quoted string is allowed on a line of po file: \n<<" << str << ">>");
 					pre_string = false;
-				} else if (!is_po_whitespace(*it)) {
-					LOG_ERROR("i18n: Unexpected characters in po file where only whitespace is expected: \'" << *it << "\':\n<<" << str << ">>");
+				} else {
+					ASSERT_LOG(is_po_whitespace(*it), "i18n: Unexpected characters in po file where only whitespace is expected: \'" << *it << "\':\n<<" << str << ">>");
 				}
 			} else {
 				if (*it == '\"') {
 					post_string = true;
 				} else if (*it == '\\') {
 					it++;
-					if (it == str.end()) {
-						LOG_ERROR("i18n: po string terminated unexpectedly after escape character: \n<<" << str << ">>");
-						return;
-					}
+					ASSERT_LOG(it != str.end(), "i18n: po string terminated unexpectedly after escape character: \n<<" << str << ">>");
 					char c = *it;
 					switch (c) {
 						case 'n': {
@@ -166,8 +160,7 @@ namespace
 							break;
 						}
 						default: {
-							LOG_ERROR("i18n: po string contained unrecognized escape sequence: \"\\" << c << "\": \n<<" << str << ">>");
-							break;
+							ASSERT_LOG(false, "i18n: po string contained unrecognized escape sequence: \"\\" << c << "\": \n<<" << str << ">>");
 						}
 					}
 				} else {
@@ -175,9 +168,7 @@ namespace
 				}
 			}
 		}
-		if (!pre_string && !post_string) {
-			LOG_ERROR("i18n: unterminated quoted string in po file:\n<<" << str << ">>");
-		}
+		ASSERT_LOG(pre_string || post_string, "i18n: unterminated quoted string in po file:\n<<" << str << ">>");
 	}
 
 	enum po_item { PO_NONE, PO_MSGID, PO_MSGSTR };

--- a/src/i18n.cpp
+++ b/src/i18n.cpp
@@ -194,10 +194,17 @@ namespace
 		for (std::string line; std::getline(ss, line); ) {
 			if (line.size() > 0 && line[0] != '#') {
 				if (line.size() >= 6 && line.substr(0,6) == "msgid ") {
-					if (current_item == PO_MSGID) {
-						LOG_DEBUG("i18n: ignoring a MSGID which had no MSGSTR: " << msgid.str());
-					} else if (current_item == PO_MSGSTR) { // This is the start of a new item, so store the previous item
-						store_message(msgid.str(), msgstr.str());
+					switch(current_item) {
+						case PO_MSGID: {
+							LOG_DEBUG("i18n: ignoring a MSGID which had no MSGSTR: " << msgid.str());
+							break;
+						}
+						case PO_MSGSTR: { // This is the start of a new item, so store the previous item
+							store_message(msgid.str(), msgstr.str());
+							break;
+						}
+						case PO_NONE:
+							break;
 					}
 					msgid.str("");
 					msgstr.str("");
@@ -230,12 +237,19 @@ namespace
 		}
 
 		// Make sure to store the very last message also
-		if (current_item == PO_MSGSTR) {
-			store_message(msgid.str(), msgstr.str());
-		} else if (current_item == PO_MSGID) {
-			LOG_DEBUG("i18n: ignoring a MSGID which had no MSGSTR: " << msgid.str());
-		} else if (current_item == PO_NONE) {
-			LOG_DEBUG("i18n: parsed a po file which had no content");
+		switch(current_item) {
+			case PO_MSGSTR: {
+				store_message(msgid.str(), msgstr.str());
+				break;
+			}
+			case PO_MSGID: {
+				LOG_DEBUG("i18n: ignoring a MSGID which had no MSGSTR: " << msgid.str());
+				break;
+			}
+			case PO_NONE: {
+				LOG_WARN("i18n: parsed a po file which had no content");
+				break;
+			}
 		}
 	}
 }

--- a/src/i18n.cpp
+++ b/src/i18n.cpp
@@ -285,10 +285,16 @@ namespace i18n
 		}
 
 		//strip the charset part of the country and language code,
+		//leave the script code if there is one
 		//e.g. "pt_BR.UTF8" --> "pt_BR"
+		//     "sr_RS.UTF-8@latin" --> "sr_RS@latin"
 		std::string trim_locale_charset(const std::string & locale) {
 			size_t found = locale.find(".");
 			if (found != std::string::npos) {
+				size_t found2 = locale.substr(found).find('@');
+				if (found2 != std::string::npos) {
+					return locale.substr(0, found) + locale.substr(found).substr(found2);
+				}
 				return locale.substr(0, found);
 			}
 			return locale;
@@ -519,6 +525,12 @@ CHECK_EQ(loc, ""); \
 		}
 		{
 			std::string loc = "sr_RS@latin";
+			const char * expected [] = { "sr_RS@latin" , "sr_RS", "sr", nullptr };
+
+			TEST_LOCALE_PROCESSING;
+		}
+		{
+			std::string loc = "sr_RS.UTF-8@latin";
 			const char * expected [] = { "sr_RS@latin" , "sr_RS", "sr", nullptr };
 
 			TEST_LOCALE_PROCESSING;

--- a/src/i18n.cpp
+++ b/src/i18n.cpp
@@ -668,16 +668,17 @@ msgstr \"baz\"");
 		ASSERT_LOG(false, "failure was expected");
 	}
 
-
-#define TEST_LOCALE_PROCESSING \
-do { \
-loc = trim_locale_charset(loc); \
-for (const char ** ptr = expected; *ptr != nullptr; ptr++) { \
-	CHECK_EQ(loc, *ptr); \
-	loc = tweak_locale(loc); \
-} \
-CHECK_EQ(loc, ""); \
-} while(0)
+	namespace {
+		void TEST_LOCALE_PROCESSING(std::string loc, const char ** const expected)
+		{
+			loc = trim_locale_charset(loc);
+			for (const char ** ptr = expected; *ptr != nullptr; ptr++) {
+				CHECK_EQ(loc, *ptr);
+				loc = tweak_locale(loc);
+			}
+			CHECK_EQ(loc, "");
+		}
+	}
 
 	UNIT_TEST(locale_processing)
 	{
@@ -685,31 +686,31 @@ CHECK_EQ(loc, ""); \
 			std::string loc = "ar";
 			const char * expected [] = { "ar", nullptr };
 
-			TEST_LOCALE_PROCESSING;
+			TEST_LOCALE_PROCESSING(loc, expected);
 		}
 		{
 			std::string loc = "be_BY";
 			const char * expected [] = { "be_BY", "be", nullptr };
 
-			TEST_LOCALE_PROCESSING;
+			TEST_LOCALE_PROCESSING(loc, expected);
 		}
 		{
 			std::string loc = "sr@latin";
 			const char * expected [] = { "sr@latin" , "sr", nullptr };
 
-			TEST_LOCALE_PROCESSING;
+			TEST_LOCALE_PROCESSING(loc, expected);
 		}
 		{
 			std::string loc = "sr_RS@latin";
 			const char * expected [] = { "sr_RS@latin" , "sr_RS", "sr", nullptr };
 
-			TEST_LOCALE_PROCESSING;
+			TEST_LOCALE_PROCESSING(loc, expected);
 		}
 		{
 			std::string loc = "sr_RS.UTF-8@latin";
 			const char * expected [] = { "sr_RS@latin" , "sr_RS", "sr", nullptr };
 
-			TEST_LOCALE_PROCESSING;
+			TEST_LOCALE_PROCESSING(loc, expected);
 		}
 	}
 }


### PR DESCRIPTION
Po parser looks quite complete after this sequence of commits.
- More rigorous checking of corner cases in parser
- Should signal an assertion failure whenever po file is malformed (with exception of msgid not followed by msgstr, which should only be a log debug signal. this allows to essentially load the pot file as a po file without errors.)
- More rigorous unit tests to check that failures are being flagged.

Also, fix a minor bug having to do with locales which have an explicit char e.g. ".UTF-8" and also a script e.g. "@latin".

Tested this also by pasting the entire po dir contents into the german mo dir, and loading in german. No assertions were observed.
