### PR TITLE
fix some compiler warnings / bugs in code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ lua.lib
 
 # random stuff
 .DS_Store
+db.json
 *~
 *.kate-swp
 *.sublime-workspace

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,11 @@ ifneq ($(USE_LUA), yes)
 USE_LUA=
 endif
 
+BASE_CXXFLAGS += -Wall -Werror
+
 ifeq ($(CXX), g++)
 GCC_GTEQ_490 := $(shell expr `$(CXX) -dumpversion | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/'` \>= 40900)
-BASE_CXXFLAGS += -Wno-literal-suffix
+BASE_CXXFLAGS += -Wno-literal-suffix -Wno-sign-compare
 ifeq "$(GCC_GTEQ_490)" "1"
 BASE_CXXFLAGS += -fdiagnostics-color=auto -fsanitize=undefined
 endif
@@ -68,9 +70,9 @@ TARBALL := /var/www/anura/anura-$(shell date +"%Y%m%d-%H%M").tar.bz2
 
 # Initial compiler options, used before CXXFLAGS and CPPFLAGS. -rdynamic -Wno-literal-suffix
 BASE_CXXFLAGS += -std=c++0x -g -fno-inline-functions \
-	-fthreadsafe-statics -Wnon-virtual-dtor -Werror \
-	-Wignored-qualifiers -Wformat -Wswitch -Wreturn-type \
-	-Wno-narrowing
+	-fthreadsafe-statics \
+	-Wno-narrowing -Wno-reorder -Wno-unused \
+	-Wno-unknown-pragmas -Wno-overloaded-virtual
 
 LDFLAGS?=-rdynamic
 

--- a/src/ColorTransform.cpp
+++ b/src/ColorTransform.cpp
@@ -39,7 +39,7 @@ namespace KRE
 //		: add_rgba_()
 	{
 		mul_rgba_[0] = mul_rgba_[1] = mul_rgba_[2] = mul_rgba_[3] = 1.0f;
-		add_rgba_[0] = add_rgba_[2] = add_rgba_[2] = add_rgba_[3] = 0.0f;
+		add_rgba_[0] = add_rgba_[1] = add_rgba_[2] = add_rgba_[3] = 0.0f;
 	}
 
 	ColorTransform::ColorTransform(const Color& color)

--- a/src/VoronoiDiagramGenerator.cpp
+++ b/src/VoronoiDiagramGenerator.cpp
@@ -1099,6 +1099,10 @@ deltax, deltay (can all be estimates).
 Performance suffers if they are wrong; better to make nsites,
 deltax, and deltay too big than too small.  (?) */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+// XXX check about this? ^
+
 bool VoronoiDiagramGenerator::voronoi(int triangulate)
 {
 	struct Site *newsite, *bot, *top, *temp, *p;
@@ -1218,6 +1222,7 @@ bool VoronoiDiagramGenerator::voronoi(int triangulate)
 	return true;
 }
 
+#pragma GCC diagnostic pop
 
 int scomp(const void *p1,const void *p2)
 {

--- a/src/base64.cpp
+++ b/src/base64.cpp
@@ -25,6 +25,8 @@
 #include "base64.hpp"
 #include "unit_test.hpp"
 
+#pragma GCC diagnostic ignored "-Wchar-subscripts"
+
 namespace base64 
 {
 	namespace 

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -96,6 +96,9 @@ extern int g_tile_size;
 using std::placeholders::_1;
 using std::placeholders::_2;
 
+#pragma GCC diagnostic ignored "-Wmissing-braces"
+// XXX: fix this in the code?
+
 namespace 
 {
 	//keep a map of editors so that when we edit a level and then later

--- a/src/file_chooser_dialog.cpp
+++ b/src/file_chooser_dialog.cpp
@@ -57,7 +57,7 @@ namespace sys
 	{
 		std::string abs_path;
 		// A path is absolute if it starts with / (linux)
-		// on windows a path is absolute if it starts with \\, x:\, \
+		// on windows a path is absolute if it starts with \\, x:\, \,
 		//boost::regex regexp(re_absolute_path);
 		//bool path_is_absolute = boost::regex_match(path, boost::regex(re_absolute_path));
 		//std::cerr << "set_default_path: path(" << path << ") is " << (path_is_absolute ? "absolute" : "relative") << std::endl;

--- a/src/formula_tokenizer.cpp
+++ b/src/formula_tokenizer.cpp
@@ -28,6 +28,8 @@
 #include "string_utils.hpp"
 #include "unit_test.hpp"
 
+#pragma GCC diagnostic ignored "-Wchar-subscripts"
+
 namespace formula_tokenizer
 {
 	namespace 

--- a/src/kre/SurfaceSDL.cpp
+++ b/src/kre/SurfaceSDL.cpp
@@ -340,6 +340,7 @@ namespace KRE
 			case BLEND_MODE_BLEND:	sdl_bm = SDL_BLENDMODE_BLEND; break;
 			case BLEND_MODE_ADD:	sdl_bm = SDL_BLENDMODE_ADD; break;
 			case BLEND_MODE_MODULATE:	sdl_bm = SDL_BLENDMODE_MOD; break;
+			default: ASSERT_LOG(false, "Surface::BlendMode had no known SDL counterpart: " << bm);
 		}
 		SDL_SetSurfaceBlendMode(surface_, sdl_bm);
 	}
@@ -372,7 +373,7 @@ namespace KRE
 		{
 			v = v - ((v >> 1) & 0x55555555);
 			v = (v & 0x33333333) + ((v >> 2) & 0x33333333);
-			return uint8_t(((v + (v >> 4) & 0xF0F0F0F) * 0x1010101) >> 24);
+			return uint8_t((((v + (v >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24);
 		}
 	}
 

--- a/src/md5.cpp
+++ b/src/md5.cpp
@@ -25,6 +25,8 @@
 
 #include "unit_test.hpp"
 
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+
 namespace md5 {
 
 std::string sum(const std::string& data)

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -49,7 +49,7 @@ namespace module
 	namespace 
 	{
 		// The base files are referred to as core.
-		module::modules core = {"core", "core", "core", ""};
+		module::modules core = {"core", "core", "core", {""}};
 
 		std::vector<module::modules>& loaded_paths() {
 			static std::vector<module::modules> result(1, core);

--- a/src/svg/svg_paint.cpp
+++ b/src/svg/svg_paint.cpp
@@ -96,7 +96,9 @@ namespace KRE
 					}
 					ASSERT_LOG(count < 3, "Too many numbers in color value");
 					cv[count] = col_val;
+					count++;
 				}
+				ASSERT_LOG(count == 3, "Too few numbers in rgb color value");
 				color_value_ = Color(cv[0],cv[1],cv[2]);
 			} else if(s.length() > 4 && s.substr(0, 4) == "url(") {
 				auto st_it = std::find(s.begin(), s.end(), '(');

--- a/src/svg/svg_transform.cpp
+++ b/src/svg/svg_transform.cpp
@@ -259,7 +259,7 @@ namespace KRE
 		
 			std::vector<double> parameters;
 
-			TransformType type;
+			boost::optional<TransformType> type;
 
 			boost::char_separator<char> seperators(" \n\t\r,", "()");
 			boost::tokenizer<boost::char_separator<char>> tok(s, seperators);
@@ -285,7 +285,8 @@ namespace KRE
 					}
 				} else if(state == STATE_NUMBER) {
 					if(*it == ")") {
-						switch(type) {
+						ASSERT_LOG(type, "svg transform type was not initialized");
+						switch(*type) {
 							case TransformType::MATRIX: {
 								matrix_transform* mtrf = new matrix_transform(parameters);
 								results.emplace_back(mtrf);

--- a/src/variant_utils.cpp
+++ b/src/variant_utils.cpp
@@ -266,7 +266,7 @@ variant interpolate_variants(variant a, variant b, float ratiof)
 			++ib;
 		}
 
-		ASSERT_LOG(ia == am.end() & ib == bm.end(), "Trying to interpolate invalid maps: " << a.write_json() << " vs " << b.write_json());
+		ASSERT_LOG(ia == am.end() && ib == bm.end(), "Trying to interpolate invalid maps: " << a.write_json() << " vs " << b.write_json());
 		return variant(&res);
 	}
 	ASSERT_LOG(false, "Trying to interpolate invalid variant values: " << a.write_json() << " vs " << b.write_json());


### PR DESCRIPTION
- Makefile uses -Wall -Werror, and we disable some of the warnings
  rather than "opting in" to warnings
- Some files get gcc pragmas to ignore warnings
- Fix some actual bugs caught by gcc "maybe-uninitialized"
  (svg rgb was not parsing correctly, fix an always uninitialized var
  in kre/SurfaceSDL.cpp)
- db.json is added to git ignore
- Some more obscure warning fixups...

Tested with gcc 4.9.2 and clang 3.5
