### PR TITLE
fix a crash which occurs when alt tabbing

### DIFF
--- a/modules/icons/data/objects/game_icon.cfg
+++ b/modules/icons/data/objects/game_icon.cfg
@@ -26,8 +26,10 @@
 
 		user_info: { type: "any" },
 
-		_update_canvas: "def() ->commands [
+		_update_canvas: "def() ->commands
 
+		if (scaling > 0,
+		[
 		set(animation, {
 			id: 'svg',
 			image: 'svg',
@@ -64,9 +66,7 @@
 			duration: -1,
 		}),
 		set(me._dirty, false)
-		]
-		
-		",
+		])",
 	},
 
 	on_process: "if(_dirty, _update_canvas())",


### PR DESCRIPTION
When I minimize argentum age, I get crashes in many gui elements
due to cairo code complaining about "canvas size = 0 x 0". I
committed several fixes similar to this to AA code also.
