### PR TITLE
add mistyped identifier suggestions to ffl

### DIFF
--- a/src/formula.cpp
+++ b/src/formula.cpp
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <boost/lexical_cast.hpp>
+#include <boost/optional/optional.hpp>
 #include <cmath>
 #include <stack>
 #include <stdio.h>
@@ -729,6 +730,47 @@ namespace game_logic
 			ConstFormulaCallableDefinitionPtr callable_def_;
 		};
 
+namespace {
+	// Calculates the edit distance between two strings.
+	class edit_distance_calculator {
+	private:
+		const std::string & a_;
+		const std::string & b_;
+
+		std::vector< std::vector<size_t> > cache_;
+
+	public:
+		edit_distance_calculator(const std::string & a, const std::string & b)
+			: a_(a)
+			, b_(b)
+			, cache_(a.size() + 1, std::vector<size_t>(b.size() + 1))
+		{
+			// cache_ stores the calculated edit distance between initial segments of a and b
+
+			for (size_t j = 0; j <= b.size(); ++j) {
+				cache_[0][j] = j;
+			}
+			for (size_t i = 1; i <= a.size(); ++i) {
+				cache_[i][0] = i;
+				for (size_t j = 1; j <= b.size(); ++j) {
+					size_t replaced = cache_[i-1][j-1] + ((a[i-1] == b[j-1]) ? 0 : 1);
+					size_t inserted = cache_[i-1][j] + 1;
+					size_t deleted  = cache_[i][j-1] + 1;
+					size_t min = std::min(replaced, std::min(inserted, deleted));
+					// transposition
+					if (i > 1 && j > 1 && a[i-1] == b[j-2] && a[i-2] == b[j-1]) {
+						min = std::min(min, cache_[i-2][j-2] + 1);
+					}
+					cache_[i][j] = min;
+				}
+			}
+		}
+		size_t operator()() {
+			return cache_[a_.size()][b_.size()];
+		}
+	};
+}
+
 		class IdentifierExpression : public FormulaExpression {
 		public:
 			IdentifierExpression(const std::string& id, ConstFormulaCallableDefinitionPtr callable_def)
@@ -764,13 +806,30 @@ namespace game_logic
 
 						std::sort(known_v.begin(), known_v.end());
 						std::string known;
+
+						// Suggest a correction
+						boost::optional<std::string> candidate_match;
+						size_t candidate_value = std::min(static_cast<size_t>(4), id_.size());
 						for(const std::string& k : known_v) {
 							known += k + " \n";
+
+							size_t d = edit_distance_calculator(id_, k)();
+							if (candidate_value > d) {
+								candidate_match = k;
+								candidate_value = d;
+							} else if (candidate_value == d) {
+								// best match so far is not unique so blank it out
+								candidate_match = boost::none;
+							}
+						}
+						std::string suggested_match = "";
+						if (candidate_match) {
+							suggested_match = "\nMaybe you meant '" + *candidate_match + "'?\n";
 						}
 						if(callable_def_->getTypeName() != nullptr) {
-							STRICT_ERROR("Unknown symbol '" << id_ << "' in " << *callable_def_->getTypeName() << " " << debugPinpointLocation() << "\nKnown symbols: " << known << "\n");
+							STRICT_ERROR("Unknown symbol '" << id_ << "' in " << *callable_def_->getTypeName() << " " << debugPinpointLocation() << suggested_match << "\nKnown symbols: " << known << "\n");
 						} else {
-							STRICT_ERROR("Unknown identifier '" << id_ << "' " << debugPinpointLocation() << "\nIdentifiers that are valid in this scope: " << known << "\n");
+							STRICT_ERROR("Unknown identifier '" << id_ << "' " << debugPinpointLocation() << suggested_match << "\nIdentifiers that are valid in this scope: " << known << "\n");
 						}
 					} else if(callable_def_) {
 						std::string type_name = "unk";
@@ -4258,6 +4317,18 @@ UNIT_TEST(formula_list_comprehension) {
 
 	CHECK_EQ(Formula(variant("[x | x <- [0,1,2,3]]")).execute(), variant(&result));
 	CHECK_EQ(Formula(variant("[x | x <- [0,1,2,3], x%2 = 1]")).execute(), Formula(variant("[1,3]")).execute());
+}
+
+UNIT_TEST(edit_distance) {
+	CHECK_EQ(edit_distance_calculator("aa", "bb")(), 2);
+	CHECK_EQ(edit_distance_calculator("ab", "bb")(), 1);
+	CHECK_EQ(edit_distance_calculator("bb", "bb")(), 0);
+	CHECK_EQ(edit_distance_calculator("abcdefg", "hijklmn")(), 7);
+	CHECK_EQ(edit_distance_calculator("abcdefg", "bcdefg")(), 1);
+	CHECK_EQ(edit_distance_calculator("abcdefg", "abcefg")(), 1);
+	CHECK_EQ(edit_distance_calculator("abcdefg", "abdcefg")(), 1);
+	CHECK_EQ(edit_distance_calculator("abcdefg", "abdcegf")(), 2);
+	CHECK_EQ(edit_distance_calculator("abcdefg", "bdcegf")(), 3);
 }
 
 BENCHMARK(formula_list_comprehension_bench) {


### PR DESCRIPTION
If an identifier has no match in ffl, anura will
- compute the edit distance to known identifiers, counting character replacement, insertion, deletion, and swapping adjacent characters as 1.
- if there is a unique known identifier of distance at most 3 (and less than the length of the typed identifier), then suggest that as a typo correction.
