### PR TITLE
Added quick loading of the current save slot via keyboard shortcut

### DIFF
--- a/src/level_runner.cpp
+++ b/src/level_runner.cpp
@@ -24,6 +24,8 @@
 #include <math.h>
 #include <climits>
 
+#include <boost/algorithm/string/replace.hpp>
+
 #include "CameraObject.hpp"
 #include "Canvas.hpp"
 #include "Font.hpp"
@@ -1312,6 +1314,20 @@ bool LevelRunner::play_cycle()
 						lvl_node = lvl_node.add_attr(variant("music"), variant(sound::current_music()));
 					}
 					sys::write_file(preferences::save_file_path(), lvl_node.write_json(true));
+				} else if(key == SDLK_l && (mod&KMOD_CTRL) && !editor_) {
+					LOG_INFO("LOADING...");
+
+					std::string level_dest = preferences::save_file_path();
+
+					if(sys::file_exists(level_dest)) {
+						boost::replace_first(level_dest, preferences::user_data_path(), "");
+						Level::portal p;
+						p.level_dest = level_dest;
+						p.dest_starting_pos = true;
+						p.saved_game = true;
+						p.transition = "instant";
+						lvl_->force_enter_portal(p);
+					}
 				} else if(key == SDLK_s && (mod&KMOD_ALT)) {
 					const std::string fname = KRE::WindowManager::getMainWindow()->saveFrameBuffer("screenshot.png");
 					if(!fname.empty()) {


### PR DESCRIPTION
It's complementary feature to existing saving via `Ctrl+S`.
Because I'm new to the engine, there can be better way to do this. Just let me know and I will fix it.
