### PR TITLE
Fix two Linux compilation problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,16 +137,11 @@ INCLUDES  := $(addprefix -I,$(SRC_DIR))
 
 vpath %.cpp $(SRC_DIR)
 
+CPPFLAGS += -MMD -MP
 define cc-command
 $1/%.o: %.cpp
 	@echo "Building:" $$<
 	@$(CCACHE) $(CXX) $(BASE_CXXFLAGS) $(CXXFLAGS) $(CPPFLAGS) $(INC) $(INCLUDES) -c -o $$@ $$<
-	@$(CXX) $(BASE_CXXFLAGS) $(CXXFLAGS) $(CPPFLAGS) $(INC) $(INCLUDES) -MM $$< > $$@.d
-	@mv -f $$@.d $$@.d.tmp
-	@sed -e 's|.*:|$$@:|' < $$@.d.tmp > $$@.d
-	@sed -e 's/.*://' -e 's/\\$$$$//' < $$@.d.tmp | fmt -1 | \
-		sed -e 's/^ *//' -e 's/$$$$/:/' >> $$@.d
-	@rm -f $$@.d.tmp
 endef
 
 .PHONY: all checkdirs clean
@@ -180,4 +175,3 @@ $(foreach bdir,$(BUILD_DIR),$(eval $(call cc-command,$(bdir))))
 
 # pull in dependency info for *existing* .o files
 -include $(OBJ:.o=.o.d)
-

--- a/src/tiled/tmx_reader.cpp
+++ b/src/tiled/tmx_reader.cpp
@@ -139,7 +139,7 @@ namespace tiled
 	void TmxReader::parseMapElement(const boost::property_tree::ptree& pt)
 	{
 		auto attributes = pt.get_child_optional("<xmlattr>");
-		ASSERT_LOG(attributes != nullptr, "map elements must have a minimum number of attributes: 'version', 'orientation', 'width', 'height', 'tilewidth', 'tileheight'");
+		ASSERT_LOG(attributes != boost::none, "map elements must have a minimum number of attributes: 'version', 'orientation', 'width', 'height', 'tilewidth', 'tileheight'");
 		auto version = attributes->get_child("version").data();
 		auto orientation = attributes->get_child("orientation").data();
 		map_->setOrientation(convert_orientation(orientation));
@@ -201,7 +201,7 @@ namespace tiled
 	void TmxReader::parseTileset(const boost::property_tree::ptree& pt)
 	{
 		auto attributes = pt.get_child_optional("<xmlattr>");
-		ASSERT_LOG(attributes != nullptr, "tileset elements must have a minimum number of attributes: 'firstgid'");
+		ASSERT_LOG(attributes != boost::none, "tileset elements must have a minimum number of attributes: 'firstgid'");
 		int firstgid = attributes->get<int>("firstgid");
 		TileSet ts(firstgid);
 		


### PR DESCRIPTION
These fix the the two problems compiling Anura on Arch Linux:
1. ccache doesn't work because the option `-MM` is unsupported. Fixed by b146ad90831a82da89e0a8f4113cd3dfa1484db0.
2. Boost headers are included in external/includes.
   1.  If I compile Anura with the bundled headers, linking fails because my boost libraries are a different version from the headers.
   2. If I remove external/includes/boost and compile with the system headers, compilation fails because of the code comparing a `boost::optional` with `nullptr`. Fixed by a139920b0402a873070c868287819fa3908f8a0e.
