### PR TITLE
Makefile: Add SANITIZE_UNDEFINED and config info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,11 @@ ifneq ($(SANITIZE_ADDRESS), yes)
 SANITIZE_ADDRESS=
 endif
 
+SANITIZE_UNDEFINED?=yes
+ifneq ($(SANITIZE_UNDEFINED), yes)
+SANITIZE_UNDEFINED=
+endif
+
 ifeq ($(OPTIMIZE),yes)
 BASE_CXXFLAGS += -O2
 endif
@@ -48,6 +53,7 @@ endif
 BASE_CXXFLAGS += -Wall -Werror
 
 ifneq (,$(findstring clang, `$(CXX)`))
+SANITIZE_UNDEFINED=
 BASE_CXXFLAGS += -Qunused-arguments -Wno-unknown-warning-option -Wno-deprecated-register
 ifeq ($(USE_LUA), yes)
 BASE_CXXFLAGS += -Wno-pointer-bool-conversion -Wno-parentheses-equality
@@ -56,7 +62,9 @@ else ifneq (, $(findstring g++, `$(CXX)`))
 GCC_GTEQ_490 := $(shell expr `$(CXX) -dumpversion | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/'` \>= 40900)
 BASE_CXXFLAGS += -Wno-literal-suffix -Wno-sign-compare
 ifeq "$(GCC_GTEQ_490)" "1"
-BASE_CXXFLAGS += -fdiagnostics-color=auto -fsanitize=undefined
+BASE_CXXFLAGS += -fdiagnostics-color=auto
+else
+SANITIZE_UNDEFINED=
 endif
 endif
 
@@ -86,6 +94,11 @@ LDFLAGS?=-rdynamic
 ifeq ($(SANITIZE_ADDRESS), yes)
 BASE_CXXFLAGS += -g3 -fsanitize=address
 LDFLAGS += -fsanitize=address
+endif
+
+# Check for sanitize-undefined option
+ifeq ($(SANITIZE_UNDEFINED), yes)
+BASE_CXXFLAGS += -fsanitize=undefined
 endif
 
 # Compiler include options, used after CXXFLAGS and CPPFLAGS.
@@ -162,6 +175,23 @@ anura: $(OBJ)
 		$(LIBS) -lboost_regex -lboost_system -lboost_filesystem -lpthread -fthreadsafe-statics
 
 checkdirs: $(BUILD_DIR)
+	@echo -e \
+	 " OPTIMIZE            : $(OPTIMIZE)\n" \
+	  "USE_CCACHE          : $(USE_CCACHE)\n" \
+	  "CCACHE              : $(CCACHE)\n" \
+	  "SANITIZE_ADDRESS    : $(SANITIZE_ADDRESS)\n" \
+	  "SANITIZE_UNDEFINED  : $(SANITIZE_UNDEFINED)\n" \
+	  "USE_DB_CLIENT       : $(USE_DB_CLIENT)\n" \
+	  "USE_BOX2D           : $(USE_BOX2D)\n" \
+	  "USE_LIBVPX          : $(USE_LIBVPX)\n" \
+	  "USE_LUA             : $(USE_LUA)\n" \
+	  "USE_SDL2            : $(USE_SDL2)\n" \
+	  "CXX                 : $(CXX)\n" \
+	  "BASE_CXXFLAGS       : $(BASE_CXXFLAGS)\n" \
+	  "CXXFLAGS            : $(CXXFLAGS)\n" \
+	  "LDFLAGS             : $(LDFLAGS)\n" \
+	  "LIBS                : $(LIBS)"
+
 
 $(BUILD_DIR):
 	@mkdir -p $@


### PR DESCRIPTION
Make it possible to disable -fsanitize=undefined, which is
required for e.g. linking against musl libc or for the aarch64
target. For these targets there is neither libasan nor libubsan.

Print the currently active configuration values before actually
building the object files. This makes it easier for the packager
to see if everything is as expected.
