### PR TITLE
Fix Linux compile issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ LDFLAGS += -fsanitize=address
 endif
 
 # Compiler include options, used after CXXFLAGS and CPPFLAGS.
-INC := -isystem external/include $(shell pkg-config --cflags x11 sdl2 glew SDL2_image SDL2_ttf libpng zlib freetype2 cairo)
+INC := -isystem external/header-only-libs $(shell pkg-config --cflags x11 sdl2 glew SDL2_image SDL2_ttf libpng zlib freetype2 cairo)
 
 ifdef STEAM_RUNTIME_ROOT
 	INC += -isystem $(STEAM_RUNTIME_ROOT)/include

--- a/Makefile
+++ b/Makefile
@@ -138,16 +138,11 @@ INCLUDES  := $(addprefix -I,$(SRC_DIR))
 
 vpath %.cpp $(SRC_DIR)
 
+CPPFLAGS += -MMD -MP
 define cc-command
 $1/%.o: %.cpp
 	@echo "Building:" $$<
 	@$(CCACHE) $(CXX) $(BASE_CXXFLAGS) $(CXXFLAGS) $(CPPFLAGS) $(INC) $(INCLUDES) -c -o $$@ $$<
-	@$(CXX) $(BASE_CXXFLAGS) $(CXXFLAGS) $(CPPFLAGS) $(INC) $(INCLUDES) -MM $$< > $$@.d
-	@mv -f $$@.d $$@.d.tmp
-	@sed -e 's|.*:|$$@:|' < $$@.d.tmp > $$@.d
-	@sed -e 's/.*://' -e 's/\\$$$$//' < $$@.d.tmp | fmt -1 | \
-		sed -e 's/^ *//' -e 's/$$$$/:/' >> $$@.d
-	@rm -f $$@.d.tmp
 endef
 
 .PHONY: all checkdirs clean
@@ -181,4 +176,3 @@ $(foreach bdir,$(BUILD_DIR),$(eval $(call cc-command,$(bdir))))
 
 # pull in dependency info for *existing* .o files
 -include $(OBJ:.o=.o.d)
-

--- a/external/header-only-libs/glm
+++ b/external/header-only-libs/glm
@@ -1,0 +1,1 @@
+../include/glm

--- a/external/header-only-libs/treetree
+++ b/external/header-only-libs/treetree
@@ -1,0 +1,1 @@
+../include/treetree


### PR DESCRIPTION
Replace the -MM flag not supported by ccache with -MMD which is
supported. This also enables simplification of the compilation
command line.

See
http://stackoverflow.com/questions/29703938/ccache-doesnt-work-with-gcc-m-flag
http://www.microhowto.info/howto/automatically_generate_makefile_dependencies.html

Fixes #99

Have Makefile only use bundled header-only libraries and not others such as boost, to avoid linking errors.

Fixes #113 
