### PR TITLE
Added "editor_opened" and "editor_closed" events.

### DIFF
--- a/src/code_editor_dialog.cpp
+++ b/src/code_editor_dialog.cpp
@@ -103,7 +103,7 @@ void CodeEditorDialog::init()
 	WidgetPtr find_label(Label::create("Find: ", col));
 	replace_label_ = Label::create("Replace: ", col);
 	status_label_ = Label::create("Ok", col);
-	error_label_ = Label::create("", col);
+	error_label_ = Label::create(" ", col);
 	addWidget(find_label, 42, 12, MOVE_DIRECTION::RIGHT);
 	addWidget(WidgetPtr(search_), MOVE_DIRECTION::RIGHT);
 	addWidget(replace_label_, MOVE_DIRECTION::RIGHT);

--- a/src/level_runner.cpp
+++ b/src/level_runner.cpp
@@ -742,7 +742,7 @@ void LevelRunner::start_editor()
 		editor_->setup_for_editing();
 		lvl_->set_editor();
 		lvl_->setAsCurrentLevel();
-		lvl_->player()->getEntity().handleEvent("editor_opened");
+		lvl_->player()->getEntity().handleEvent("open_editor");
 		initHistorySlider();
 	} else {
 		//Pause the game and set the level to its original
@@ -773,7 +773,7 @@ void LevelRunner::close_editor()
 	history_trails_.clear();
 	lvl_->mutateValue("zoom", variant(1));
 	lvl_->set_editor(false);
-	lvl_->player()->getEntity().handleEvent("editor_closed");
+	lvl_->player()->getEntity().handleEvent("close_editor");
 	paused = false;
 	show_pause_title();
 	controls::read_until(lvl_->cycle());

--- a/src/level_runner.cpp
+++ b/src/level_runner.cpp
@@ -742,6 +742,7 @@ void LevelRunner::start_editor()
 		editor_->setup_for_editing();
 		lvl_->set_editor();
 		lvl_->setAsCurrentLevel();
+		lvl_->player()->getEntity().handleEvent("editor_opened");
 		initHistorySlider();
 	} else {
 		//Pause the game and set the level to its original
@@ -772,6 +773,7 @@ void LevelRunner::close_editor()
 	history_trails_.clear();
 	lvl_->mutateValue("zoom", variant(1));
 	lvl_->set_editor(false);
+	lvl_->player()->getEntity().handleEvent("editor_closed");
 	paused = false;
 	show_pause_title();
 	controls::read_until(lvl_->cycle());


### PR DESCRIPTION
Also fixed a bug which caused the engine to crash on Linux. (Specifically, mousing over the "Ok" text in the code editor would cause Anura to crash because it expected a non-empty string. For some reason, this isn't a problem on Windows.)

EDIT: I've adjusted the event names to match the style of the other, commonly used event names. (i.e. "on_start_level" instead of "on_level_started")
