### PR TITLE
Avoid error due to using GLSL 1.5 when unsupported

### DIFF
--- a/src/kre/ShadersOGL.cpp
+++ b/src/kre/ShadersOGL.cpp
@@ -696,7 +696,7 @@ namespace KRE
 					// special case for font-shader to work around amd bug.
 					std::string font_shader_vertex_shader;
 					variant node;
-					if(GLEW_ARB_explicit_attrib_location) {
+					if(GLEW_ARB_explicit_attrib_location && glewIsSupported("GL_VERSION_3_2")) {
 						font_shader_vertex_shader = font_shader_vs_layout;
 					} else {
 						font_shader_vertex_shader = font_shader_vs;


### PR DESCRIPTION
Only use the "font_shader_vs_layout" shader program if OpenGL 3.2 is
supported. According to https://en.wikipedia.org/wiki/OpenGL_Shading_Language#Versions
this is required for GLSL 1.5.

Fixes #137
