### PR TITLE
Do not count references to decimal variants.

### DIFF
--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -889,13 +889,13 @@ variant::variant(game_logic::ConstFormulaPtr fml, const std::vector<std::string>
 const variant& variant::operator=(const variant& v)
 {
 	if(&v != this) {
-		if(type_ > VARIANT_TYPE_INT) {
+		if (type_ > VARIANT_TYPE_DECIMAL) {
 			release();
 		}
 
 		type_ = v.type_;
 		value_ = v.value_;
-		if(type_ > VARIANT_TYPE_INT) {
+		if (type_ > VARIANT_TYPE_DECIMAL) {
 			increment_refcount();
 		}
 	}

--- a/src/variant.hpp
+++ b/src/variant.hpp
@@ -160,13 +160,18 @@ public:
 
 	//only call the non-inlined release() function if we have a type
 	//that needs releasing.
-	~variant() { unregisterGlobalVariant(this); if(type_ > VARIANT_TYPE_INT) { release(); } }
+	~variant() {
+		unregisterGlobalVariant(this);
+		if (type_ > VARIANT_TYPE_DECIMAL) {
+			release();
+		}
+	}
 
 	variant(const variant& v) {
 		registerGlobalVariant(this);
 		type_ = v.type_;
 		value_ = v.value_;
-		if(type_ > VARIANT_TYPE_INT) {
+		if (type_ > VARIANT_TYPE_DECIMAL) {
 			increment_refcount();
 		}
 	}
@@ -187,7 +192,7 @@ public:
 	const variant& operator=(variant&& v)
 	{
 		if(&v != this) {
-			if(type_ > VARIANT_TYPE_INT) {
+			if (type_ > VARIANT_TYPE_DECIMAL) {
 				release();
 			}
 


### PR DESCRIPTION
At branch 'dev-no-decimal-refcount-mgmt'.

Given decimal typed variants are immutable - at least they very
probably they should, and that is congruent with the inner code of the
functions releasing and increasing reference counts
('variant::release()' and 'variant::increment_refcount()',
respectively); do not use unnecesarily the reference count management
sources on them, for a symbolic performance increase and an increased
harmony of the sources.

Changes are somewhat fine grain and self evident, but even though,
this commit is specifically passing the Anura automated test suite,
and both Frogatto and Argentum Age seem to be mostly OK with these
changes.

Cheers and regards,