### PR TITLE
Use HTTPS for anonymous submodule clone

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "imgui"]
 	path = imgui
-	url = git@github.com:sweetkristas/imgui.git
+	url = https://github.com/sweetkristas/imgui


### PR DESCRIPTION
Fixes #173.

Without this change I get:
```
$ git submodule update --init
Cloning into '/home/akien/Mageia/Sandbox/argentumage/anura/imgui'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:sweetkristas/imgui.git' into submodule path '/home/akien/Mageia/Sandbox/argentumage/anura/imgui' failed
Failed to clone 'imgui'. Retry scheduled
Cloning into '/home/akien/Mageia/Sandbox/argentumage/anura/imgui'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

After the change, and after cleaning up my `.git/config` manually to remove the old init URL, I get:
```
$ git submodule update --init
Submodule 'imgui' (https://github.com/sweetkristas/imgui) registered for path 'imgui'
Cloning into '/home/akien/Mageia/Sandbox/argentumage/anura/imgui'...
Submodule path 'imgui': checked out 'beb0ea7b47a4620c62253d5193ead0af120ec3ba'
```