### PR TITLE
Makefile: Fix display of configure report on Bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ anura: $(OBJ)
 		$(LIBS) -lboost_regex -lboost_system -lboost_filesystem -lboost_locale -licui18n -licuuc -licudata -lpthread -fthreadsafe-statics
 
 checkdirs: $(BUILD_DIR)
-	@echo \
+	@echo -e \
 	  " OPTIMIZE            : $(OPTIMIZE)\n" \
 	  "USE_CCACHE          : $(USE_CCACHE)\n" \
 	  "CCACHE              : $(CCACHE)\n" \
@@ -213,7 +213,7 @@ clean:
 
 unittests: anura
 	./anura --tests
-	    
+
 tarball: unittests
 	@strip anura
 	@tar --transform='s,^,anura/,g' -cjf $(TARBALL) anura data/ images/


### PR DESCRIPTION
Without this change, the output on my system (Mageia 6 x86_64, Bash 4.3.48) is:
```
$ make
 OPTIMIZE            : yes\n USE_CCACHE          : Usage: which [options] [--] COMMAND [...] Write the full path of COMMAND(s) to standard output.    --version, -[vV] Print version and exit successfully.   --help,          Print this help and exit successfully.   --skip-dot       Skip directories in PATH that start with a dot.   --skip-tilde     Skip directories in PATH that start with a tilde.   --show-dot       Don't expand a dot to current directory in output.   --show-tilde     Output a tilde for HOME directory for non-root.   --tty-only       Stop processing options on the right if not on tty.   --all, -a        Print all matches in PATH, not just the first   --read-alias, -i Read list of aliases from stdin.   --skip-alias     Ignore option --read-alias; don't read stdin.   --read-functions Read shell functions from stdin.   --skip-functions Ignore option --read-functions; don't read stdin.  Recommended use is to write the output of (alias; declare -f) to standard input, so that which can show aliases and shell functions. See which(1) for examples.  If the options --read-alias and/or --read-functions are specified then the output can be a full alias or function definition, optionally followed by the full path of each command used inside of those.  Report bugs to <which-bugs@gnu.org>.\n CCACHE              : \n SANITIZE_ADDRESS    : \n SANITIZE_UNDEFINED  : \n USE_DB_CLIENT       : no\n USE_BOX2D           : yes\n USE_LIBVPX          : yes\n USE_LUA             : yes\n USE_SDL2            : yes\n CXX                 : g++\n BASE_CXXFLAGS       : -O2 -Wall -Werror -Wno-literal-suffix -Wno-sign-compare -Wsuggest-override -fdiagnostics-color=auto -DUSE_LUA -std=c++0x -g -fno-inline-functions -fthreadsafe-statics -Wno-narrowing -Wno-reorder -Wno-unused -Wno-unknown-pragmas -Wno-overloaded-virtual -DUSE_LIBVPX -DUSE_SVG -DUSE_IMGUI\n CXXFLAGS            : \n LDFLAGS             : -rdynamic\n INC                 : -isystem external/header-only-libs -D_REENTRANT -I/usr/include/SDL2 -I/usr/include/cairo -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/libxml2 -I/usr/include/freetype2 -I/usr/include/libdrm -I/usr/include/libpng16  -I/usr/include/cairo -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/libxml2 -I/usr/include/freetype2 -I/usr/include/libdrm -I/usr/include/libpng16 -Iimgui\n LIBS                : -lX11 -lGL -lGLEW -lGLU -lGL -lSDL2_image -lSDL2 -lpng16 -lz -lfreetype -lcairo -lSDL2_ttf -logg -lvorbis -lvorbisfile -lrt -lvpx -lm -lcairo
Building: src/kre/imgui_impl_sdl_gl3.cpp
```

```
$ make
 OPTIMIZE            : yes
 USE_CCACHE          : Usage: which [options] [--] COMMAND [...] Write the full path of COMMAND(s) to standard output.    --version, -[vV] Print version and exit successfully.   --help,          Print this help and exit successfully.   --skip-dot       Skip directories in PATH that start with a dot.   --skip-tilde     Skip directories in PATH that start with a tilde.   --show-dot       Don't expand a dot to current directory in output.   --show-tilde     Output a tilde for HOME directory for non-root.   --tty-only       Stop processing options on the right if not on tty.   --all, -a        Print all matches in PATH, not just the first   --read-alias, -i Read list of aliases from stdin.   --skip-alias     Ignore option --read-alias; don't read stdin.   --read-functions Read shell functions from stdin.   --skip-functions Ignore option --read-functions; don't read stdin.  Recommended use is to write the output of (alias; declare -f) to standard input, so that which can show aliases and shell functions. See which(1) for examples.  If the options --read-alias and/or --read-functions are specified then the output can be a full alias or function definition, optionally followed by the full path of each command used inside of those.  Report bugs to <which-bugs@gnu.org>.
 CCACHE              : 
 SANITIZE_ADDRESS    : 
 SANITIZE_UNDEFINED  : 
 USE_DB_CLIENT       : no
 USE_BOX2D           : yes
 USE_LIBVPX          : yes
 USE_LUA             : yes
 USE_SDL2            : yes
 CXX                 : g++
 BASE_CXXFLAGS       : -O2 -Wall -Werror -Wno-literal-suffix -Wno-sign-compare -Wsuggest-override -fdiagnostics-color=auto -DUSE_LUA -std=c++0x -g -fno-inline-functions -fthreadsafe-statics -Wno-narrowing -Wno-reorder -Wno-unused -Wno-unknown-pragmas -Wno-overloaded-virtual -DUSE_LIBVPX -DUSE_SVG -DUSE_IMGUI
 CXXFLAGS            : 
 LDFLAGS             : -rdynamic
 INC                 : -isystem external/header-only-libs -D_REENTRANT -I/usr/include/SDL2 -I/usr/include/cairo -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/libxml2 -I/usr/include/freetype2 -I/usr/include/libdrm -I/usr/include/libpng16  -I/usr/include/cairo -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/libxml2 -I/usr/include/freetype2 -I/usr/include/libdrm -I/usr/include/libpng16 -Iimgui
 LIBS                : -lX11 -lGL -lGLEW -lGLU -lGL -lSDL2_image -lSDL2 -lpng16 -lz -lfreetype -lcairo -lSDL2_ttf -logg -lvorbis -lvorbisfile -lrt -lvpx -lm -lcairo
Building: src/kre/imgui_impl_sdl_gl3.cpp
```

The issue with `USE_CCACHE` is due to `CCACHE?=ccache` not being expanded at the time where `USE_CCACHE?=$(shell which ${CCACHE})` is called, so the shell ends up getting `which <nothing>` and errors out. But there are other issues with your current logic which I'm not sure how to best fix just yet, so I'll open an issue.