### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/src/formula_function.cpp
+++ b/src/formula_function.cpp
@@ -44,9 +44,7 @@
 #define bmround	round
 #endif
 
-#ifndef __APPLE__
-    #include <malloc.h>
-#endif
+#include <stdlib.h>
 
 #include "geometry.hpp"
 

--- a/src/frame.cpp
+++ b/src/frame.cpp
@@ -893,7 +893,7 @@ void Frame::drawCustom(graphics::AnuraShaderPtr shader, int x, int y, const std:
 	getRectInTexture(time, info);
 	rectf rf = blit_target_.getTexture()->getSourceRectNormalised();
 
-	std::array<float, 4> r = { rf.x1(), rf.y1(), rf.x2(), rf.y2() };
+	std::array<float, 4> r = { { rf.x1(), rf.y1(), rf.x2(), rf.y2() } };
 
 	x += static_cast<int>((face_right ? info->x_adjust : info->x2_adjust) * scale_);
 	y += static_cast<int>(info->y_adjust * scale_);
@@ -1006,7 +1006,7 @@ void Frame::drawCustom(graphics::AnuraShaderPtr shader, int x, int y, const floa
 	getRectInTexture(time, info);
 	rectf rf = blit_target_.getTexture()->getSourceRectNormalised();
 
-	std::array<float, 4> r = { rf.x1(), rf.y1(), rf.x2(), rf.y2() };
+	std::array<float, 4> r = { { rf.x1(), rf.y1(), rf.x2(), rf.y2() } };
 	
 	x += static_cast<int>((face_right ? info->x_adjust : info->x2_adjust) * scale_);
 	y += static_cast<int>(info->y_adjust * scale_);

--- a/src/md5.cpp
+++ b/src/md5.cpp
@@ -195,7 +195,7 @@ void MD5Final(uint8_t digest[16], struct MD5Context *ctx)
 void MD5Transform(uint32_t buf[4], uint32_t in[16])
 
 {
-    register uint32_t a, b, c, d;
+    uint32_t a, b, c, d;
 
     a = buf[0];
     b = buf[1];

--- a/src/simplex_noise.cpp
+++ b/src/simplex_noise.cpp
@@ -72,7 +72,7 @@ namespace noise
 		{
 			int bx0, bx1, by0, by1, b00, b10, b01, b11;
 			float rx0, rx1, ry0, ry1, *q, sx, sy, a, b, t, u, v;
-			register int i, j;
+			int i, j;
 
 			if (start) {
 				start = false;
@@ -110,7 +110,7 @@ namespace noise
 		{
 			int bx0, bx1, by0, by1, bz0, bz1, b00, b10, b01, b11;
 			float rx0, rx1, ry0, ry1, rz0, rz1, *q, sy, sz, a, b, c, d, t, u, v;
-			register int i, j;
+			int i, j;
 
 			if (start) {
 				start = false;

--- a/src/tbs_matchmaking_server.cpp
+++ b/src/tbs_matchmaking_server.cpp
@@ -33,10 +33,8 @@
 #include <iostream>
 
 #include <sys/types.h>
-#ifdef __linux__
 #include <sys/wait.h>
 #include <unistd.h>
-#endif
 
 #include "asserts.hpp"
 #include "db_client.hpp"


### PR DESCRIPTION
These commits fix the following build failures on OpenBSD/amd64 (clang-5.0.1).

    Building: src/md5.cpp
    src/md5.cpp:198:5: error: 'register' storage class specifier is deprecated and incompatible with C++17 [-Werror,-Wdeprecated-register]
        register uint32_t a, b, c, d;
        ^~~~~~~~~
    src/md5.cpp:198:5: error: 'register' storage class specifier is deprecated and incompatible with C++17 [-Werror,-Wdeprecated-register]
        register uint32_t a, b, c, d;
        ^~~~~~~~~
    src/md5.cpp:198:5: error: 'register' storage class specifier is deprecated and incompatible with C++17 [-Werror,-Wdeprecated-register]
        register uint32_t a, b, c, d;
        ^~~~~~~~~
    src/md5.cpp:198:5: error: 'register' storage class specifier is deprecated and incompatible with C++17 [-Werror,-Wdeprecated-register]
        register uint32_t a, b, c, d;
        ^~~~~~~~~
    4 errors generated.
    gmake: *** [Makefile:228: build/md5.o] Error 1
    cathet$ vi src/md5.cpp

    Building: src/simplex_noise.cpp
    src/simplex_noise.cpp:75:4: error: 'register' storage class specifier is deprecated and incompatible with C++17 [-Werror,-Wdeprecated-register]
                            register int i, j;
                            ^~~~~~~~~
    src/simplex_noise.cpp:75:4: error: 'register' storage class specifier is deprecated and incompatible with C++17 [-Werror,-Wdeprecated-register]
                            register int i, j;
                            ^~~~~~~~~
    src/simplex_noise.cpp:113:4: error: 'register' storage class specifier is deprecated and incompatible with C++17 [-Werror,-Wdeprecated-register]
                            register int i, j;
                            ^~~~~~~~~
    src/simplex_noise.cpp:113:4: error: 'register' storage class specifier is deprecated and incompatible with C++17 [-Werror,-Wdeprecated-register]
                            register int i, j;
                            ^~~~~~~~~
    4 errors generated.
    gmake: *** [Makefile:228: build/simplex_noise.o] Error 1

    Building: src/tbs_matchmaking_server.cpp
    src/tbs_matchmaking_server.cpp:318:46: error: use of undeclared identifier 'WNOHANG'
                    const pid_t pid = waitpid(-1, &pid_status, WNOHANG);
                                                               ^
    src/tbs_matchmaking_server.cpp:1712:59: error: use of undeclared identifier 'WNOHANG'
                            const int res = waitpid(child_admin_process_, &status, WNOHANG);
                                                                                   ^
    2 errors generated.
    gmake: *** [Makefile:228: build/tbs_matchmaking_server.o] Error 1

    Building: src/frame.cpp
    src/frame.cpp:896:29: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
            std::array<float, 4> r = { rf.x1(), rf.y1(), rf.x2(), rf.y2() };
                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                       {                                 }
    src/frame.cpp:1009:29: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
            std::array<float, 4> r = { rf.x1(), rf.y1(), rf.x2(), rf.y2() };
                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                       {                                 }
    2 errors generated.
    gmake: *** [Makefile:228: build/frame.o] Error 1

    Building: src/formula_function.cpp
    In file included from src/formula_function.cpp:31:
    /usr/local/include/boost/uuid/sha1.hpp:13:9: warning: This header is
          implementation detail and provided for backwards compatibility.
          [-W#pragma-messages]
    #pragma message("This header is implementation detail and provided for b...
            ^
    In file included from src/formula_function.cpp:48:
    /usr/include/malloc.h:4:2: error: "<malloc.h> is obsolete, use <stdlib.h>"
          [-Werror,-W#warnings]
    #warning "<malloc.h> is obsolete, use <stdlib.h>"
     ^
    1 warning and 1 error generated.
    gmake: *** [Makefile:228: build/formula_function.o] Error 1