### PR TITLE
Remove SDL_Renderer in KRE/WindowManager

### DIFF
--- a/src/kre/WindowManager.cpp
+++ b/src/kre/WindowManager.cpp
@@ -84,7 +84,6 @@ namespace KRE
 		explicit SDLWindow(int width, int height, const variant& hints) 
 			: Window(width, height, hints),
 			  renderer_hint_(),
-			  renderer_(nullptr),
 			  context_(nullptr),
 			  nonfs_width_(width),
 			  nonfs_height_(height),
@@ -260,9 +259,6 @@ namespace KRE
 #ifdef USE_IMGUI
 				ImGui_ImplSdlGL3_Shutdown();
 #endif
-				if(getDisplayDevice()->ID() != DisplayDevice::DISPLAY_DEVICE_SDL) {
-					SDL_DestroyRenderer(renderer_);
-				}
 				getDisplayDevice().reset();
 				if(context_) {
 					SDL_GL_DeleteContext(context_);
@@ -282,8 +278,6 @@ namespace KRE
 				if(vSync()) {
 					rnd_flags |= SDL_RENDERER_PRESENTVSYNC;
 				}
-				renderer_ = SDL_CreateRenderer(window_.get(), -1, rnd_flags);
-				ASSERT_LOG(renderer_ != nullptr, "Failed to create renderer: " << SDL_GetError() << "; Windows details: " << w << "x" << h << " wnd_flags = " << wnd_flags);				
 			}
 
 			ASSERT_LOG(window_ != nullptr, "Failed to create window: " << SDL_GetError());
@@ -489,7 +483,6 @@ namespace KRE
 
 		SDL_WindowPtr window_;
 		SDL_GLContext context_;
-		SDL_Renderer* renderer_;
 		std::vector<std::string> renderer_hint_;
 
 		// Width of the window before changing to full-screen mode


### PR DESCRIPTION
It is not actually used for drawing, and with SDL2 2.0.10 it causes the
window to become white after resize

Fixes #294