### PR TITLE
Update INSTALL.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,19 +1,19 @@
 Prerequisites:
 
-You need a recent compiler, because of the use of C++11 features in the engine. The minimum 
+You need a recent compiler, because of the use of C++11 features in the engine. The minimum
 required version of GCC is 4.8. Versions of clang post 3.1 should work as well. There are build
 files for MSVC (requires 2019 desktop edition) for windows and Xcode (requires 4.6 or later).
 
 Please see https://github.com/anura-engine/anura/wiki/Building-On-Windows for Windows builds.
 
-You'll need to have these libraries with equivalent development versions to 
+You'll need to have these libraries with equivalent development versions to
 build the Anura engine:
 
- 1.50.0 <= boost_iostreams  <= 1.72.0
- 1.50.0 <= boost_filesystem <= 1.72.0
- 1.50.0 <= boost_regex      <= 1.72.0
- 1.50.0 <= boost_asio       <= 1.72.0
- 1.50.0 <= boost_system     <= 1.72.0
+ 1.50.0 <= boost_iostreams  <= 1.73.0
+ 1.50.0 <= boost_filesystem <= 1.73.0
+ 1.50.0 <= boost_regex      <= 1.73.0
+ 1.50.0 <= boost_asio       <= 1.73.0
+ 1.50.0 <= boost_system     <= 1.73.0
  libsdl >= 2.0.0
  libsdl-image >= 2.0.0 (with png support)
  libsdl-mixer >= 2.0.0 (with Vorbis support)
@@ -28,8 +28,8 @@ Building:
 
 It is recommended to install the program 'ccache' as this can considerably
 speed up build times for subsequent builds. This is however not required.
-To build, type 'make'. The Makefile will probably work. :) If it doesn't you 
-may have to tweak it for your platform. The executable 'anura' will be 
+To build, type 'make'. The Makefile will probably work. :) If it doesn't you
+may have to tweak it for your platform. The executable 'anura' will be
 created which you can run.
 
 To access the level editor, press CTRL-E during the game.

--- a/INSTALL
+++ b/INSTALL
@@ -9,11 +9,11 @@ Please see https://github.com/anura-engine/anura/wiki/Building-On-Windows for Wi
 You'll need to have these libraries with equivalent development versions to 
 build the Anura engine:
 
- 1.50.0 <= boost_iostreams  <= 1.71.0
- 1.50.0 <= boost_filesystem <= 1.71.0
- 1.50.0 <= boost_regex      <= 1.71.0
- 1.50.0 <= boost_asio       <= 1.71.0
- 1.50.0 <= boost_system     <= 1.71.0
+ 1.50.0 <= boost_iostreams  <= 1.72.0
+ 1.50.0 <= boost_filesystem <= 1.72.0
+ 1.50.0 <= boost_regex      <= 1.72.0
+ 1.50.0 <= boost_asio       <= 1.72.0
+ 1.50.0 <= boost_system     <= 1.72.0
  libsdl >= 2.0.0
  libsdl-image >= 2.0.0 (with png support)
  libsdl-mixer >= 2.0.0 (with Vorbis support)


### PR DESCRIPTION
Checked Boost 1.73.0; cleaned, compiled, reclaimed the specific regex, was provided, then link, built, ran.

This causes https://github.com/anura-engine/anura/pull/307 to become obsolete.