### PR TITLE
Basic CI - Linux

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/.github/workflows"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/pr-smoketest-debian.yaml
+++ b/.github/workflows/pr-smoketest-debian.yaml
@@ -1,0 +1,60 @@
+name: Smoketest / Informative / Debian
+on:
+  pull_request:
+  merge_group:
+
+jobs:
+  test:
+    name: Compilers
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        debian:
+          # Bullseye is the oldest Debian with a new enough glm
+          - "bullseye" # 11
+          - "bookworm" # 12
+          - "trixie" # 13
+        compiler:
+          - g++
+          - clang
+    container: debian:${{ matrix.debian }}-slim
+    steps:
+      - name: Install Dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt-get -qq update
+          apt-get -qq upgrade -y
+          apt-get -qq install -y --no-install-recommends \
+            ca-certificates \
+            git \
+            ${{ matrix.compiler }} \
+            libboost-dev \
+            libboost-filesystem-dev \
+            libboost-locale-dev \
+            libboost-regex-dev \
+            libboost-system-dev \
+            libcairo2-dev \
+            libglew-dev \
+            libglm-dev \
+            libsdl2-dev \
+            libsdl2-image-dev \
+            libsdl2-mixer-dev \
+            libsdl2-ttf-dev \
+            libvorbis-dev \
+            make
+
+      - name: Checkout Anura
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          submodules: true
+
+      - name: Build Anura
+        env:
+          CXX: ${{ matrix.compiler }}
+        # Number of cores * 3
+        run: make -j "$(($(getconf _NPROCESSORS_ONLN) * 3))"
+
+      - name: Run Unit Tests
+        run: ./anura --tests

--- a/.github/workflows/pr-smoketest-fedora.yaml
+++ b/.github/workflows/pr-smoketest-fedora.yaml
@@ -1,0 +1,58 @@
+name: Smoketest / Informative / Fedora
+on:
+  pull_request:
+  merge_group:
+
+jobs:
+  test:
+    name: Compilers
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        fedora:
+          # 32 is the oldest Fedora with a new enough glm
+          - "32"
+          - "33"
+          - "34"
+          - "35"
+          - "36"
+          - "37"
+          - "38"
+          - "39"
+        compiler:
+          - g++
+          - clang
+    container: fedora:${{ matrix.fedora }}
+    steps:
+      - name: Install Dependencies
+        run: |
+            dnf -y update
+            dnf -y install \
+                git \
+                ${{ matrix.compiler }} \
+                make \
+                which \
+                SDL2-devel \
+                boost-devel \
+                glm-devel \
+                glew-devel \
+                cairo-devel \
+                SDL2_ttf-devel \
+                SDL2_image-devel \
+                SDL2_mixer-devel \
+                libvorbis-devel
+
+      - name: Checkout Anura
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+            submodules: true
+
+      - name: Build Anura
+        env:
+          CXX: ${{ matrix.compiler }}
+        # Number of cores * 3
+        run: make -j "$(($(getconf _NPROCESSORS_ONLN) * 3))"
+
+      - name: Run Unit Tests
+        run: ./anura --tests

--- a/.github/workflows/pr-smoketest-opensuse-leap.yaml
+++ b/.github/workflows/pr-smoketest-opensuse-leap.yaml
@@ -1,0 +1,68 @@
+name: Smoketest / Informative / openSUSE Leap
+on:
+  pull_request:
+  merge_group:
+
+jobs:
+  test:
+    name: Compilers
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        suse:
+          # 15.3 is the oldest openSUSE Leap with a new enough glm
+          - "15.3"
+          - "15.4"
+          - "15.5"
+        compiler:
+          - g++
+          - clang
+    container: opensuse/leap:${{ matrix.suse }}
+    steps:
+      - name: Resolve Compiler Package Name
+        run: |
+          if [[ ${{ matrix.compiler }} == g++ ]]
+          then
+            echo compiler=gcc-c++ >> "$GITHUB_ENV"
+          else
+            echo compiler=clang >> "$GITHUB_ENV"
+          fi
+
+      - name: Install Dependencies
+        run: |
+          zypper --non-interactive update
+          zypper --non-interactive install \
+            git \
+            ${{ env.compiler }} \
+            make \
+            which \
+            libSDL2-devel \
+            glm-devel \
+            glew-devel \
+            boost-devel \
+            libSDL2_image-devel \
+            cairo-devel \
+            libSDL2_ttf-devel \
+            libSDL2_mixer-devel \
+            libvorbis-devel \
+            libicu-devel \
+            libboost_system*6*devel \
+            libboost_locale*6*devel \
+            libboost_regex*6*devel \
+            libboost_filesystem*6*devel \
+            libboost_thread*6*devel
+
+      - name: Checkout Anura
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+            submodules: true
+
+      - name: Build Anura
+        env:
+          CXX: ${{ matrix.compiler }}
+        # Number of cores * 3
+        run: make -j "$(($(getconf _NPROCESSORS_ONLN) * 3))"
+
+      - name: Run Unit Tests
+        run: ./anura --tests

--- a/.github/workflows/pr-smoketest-ubuntu.yaml
+++ b/.github/workflows/pr-smoketest-ubuntu.yaml
@@ -1,0 +1,57 @@
+name: Smoketest / Informative / Ubuntu
+on:
+  pull_request:
+  merge_group:
+
+jobs:
+  test:
+    name: Compilers
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu:
+          - "22.04" # LTS only for sanity
+        compiler:
+          - g++
+          - clang
+    container: ubuntu:${{ matrix.ubuntu }}
+    steps:
+      - name: Install Dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt-get -qq update
+          apt-get -qq upgrade -y
+          apt-get -qq install -y --no-install-recommends \
+            ca-certificates \
+            git \
+            ${{ matrix.compiler }} \
+            libboost-dev \
+            libboost-filesystem-dev \
+            libboost-locale-dev \
+            libboost-regex-dev \
+            libboost-system-dev \
+            libcairo2-dev \
+            libglew-dev \
+            libglm-dev \
+            libsdl2-dev \
+            libsdl2-image-dev \
+            libsdl2-mixer-dev \
+            libsdl2-ttf-dev \
+            libvorbis-dev \
+            make
+
+      - name: Checkout Anura
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          submodules: true
+
+      - name: Build Anura
+        env:
+          CXX: ${{ matrix.compiler }}
+        # Number of cores * 3
+        run: make -j "$(($(getconf _NPROCESSORS_ONLN) * 3))"
+
+      - name: Run Unit Tests
+        run: ./anura --tests

--- a/.github/workflows/push-unit-tests-dynamic-linux.yaml
+++ b/.github/workflows/push-unit-tests-dynamic-linux.yaml
@@ -1,0 +1,46 @@
+name: Unit Tests / Required / Dynamic / Linux
+on: push
+
+jobs:
+  test:
+    name: Ubuntu
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install Dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get -qq upgrade -y
+          sudo apt-get -qq install -y --no-install-recommends \
+            ca-certificates \
+            git \
+            clang \
+            libboost-dev \
+            libboost-filesystem-dev \
+            libboost-locale-dev \
+            libboost-regex-dev \
+            libboost-system-dev \
+            libcairo2-dev \
+            libglew-dev \
+            libglm-dev \
+            libsdl2-dev \
+            libsdl2-image-dev \
+            libsdl2-mixer-dev \
+            libsdl2-ttf-dev \
+            libvorbis-dev \
+            make
+
+      - name: Checkout Anura
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          submodules: true
+
+      - name: Build Anura
+        env:
+          CXX: clang
+        # Number of cores * 3
+        run: make -j "$(($(getconf _NPROCESSORS_ONLN) * 3))"
+
+      - name: Run Unit Tests
+        run: ./anura --tests

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Anura Engine
+
 ![](https://raw.github.com/anura-engine/anura/master/utils/Logo%20Images/Anura%20Logo.png)
 
 Anura is the tech behind the spectacular [Frogatto & Friends](https://github.com/frogatto/frogatto/wiki). It is a fully-featured game engine, free for commercial and non-commercial use.
@@ -5,3 +7,52 @@ Anura is the tech behind the spectacular [Frogatto & Friends](https://github.com
 Note: For historic reasons – unlike most projects – Anura's main development branch is `trunk` as opposed to `master`. For example, to clone the repository, you might run `git clone --branch trunk git@github.com:anura-engine/anura.git`.
 
 To compile Anura for [Argentum Age](https://github.com/davewx7/citadel) (formerly Citadel), use the `argentum-age` branch. There are some issues on `trunk` which prevent AA from running there at the moment.
+
+## CI
+
+![Unit Tests / Required / Dynamic / Linux](https://github.com/anura-engine/anura/actions/workflows/push-unit-tests-dynamic-linux.yaml/badge.svg?branch=trunk)
+
+At the time of writing (2023-07) the CI setup tests the following permutations:
+
+On every push:
+
+* Unit Tests
+  * Ubuntu 22.04 / clang
+  * NOT IMPLEMENTED Windows
+  * NOT IMPLEMENTED macOS
+
+On Pull Requests and Merge Queue events:
+
+* Smoketest dynamic builds on Linux (both g++ and clang)
+  * Debian
+    * 11 / Bullseye
+    * 12 / Bookworm
+    * 13 / Trixie
+  * Ubuntu
+    * 22.04 / Jammy Jellyfish
+  * Fedora
+    * 32
+    * 33
+    * 34
+    * 35
+    * 36
+    * 37
+    * 38
+    * 39
+  * openSUSE Leap
+    * 15.3
+    * 15.4
+    * 15.5
+
+This set should cover most popular use cases and also derivative distributions
+of these root distributions. There are no plans to test on rolling release
+distributions: on those you are on your own and we welcome the heads up if
+something breaks for you and can take a look, but will not guarantee a rapid
+fix. Pull requests welcome.
+
+Smoketest static builds on Linux:
+
+* NOT IMPLEMENTED Steam
+
+All publishing builds will happen from the module side, most notably from
+[Frogatto](https://github.com/frogatto/frogatto).


### PR DESCRIPTION
Flow of a Unit Test and a Smoketest run:

- Install dependencies
- Git clone
- Build
- Link
- Run the unit tests

Unit tests happen on every push.

Smoke tests happen on PRs and Merge Queue events. Smoke tests permutate both g++ and clang on currently functional recent versions of Debian, Ubuntu, Fedora and openSuse Leap.

The unit test runs which happen on every push one could consider making a hard gate for merging.

Smoke tests should be considered an informative soft gate, a curiosity just to see where Anura still compiles ok out of the box. An appropriate reaction to these going red, depending on what changed and why it is going red, can be to simply drop testing that platform and to amend the documentation.

This causes over 30 builds per PR, but considering the free tier allows us to do up to 256 builds per push, this is not something Github would consider excessive yet.

The builds tend to take between 15 and 25 minutes, depending on the platform and the compiler used. `clang` is in general faster than `g++`. The way to whittle this down is to simply delete unused parts of the engine, but I'd not like to engage in that before we have a solid multi platform quality signal in place.

Additionally there is a Dependabot configuration for automatically keeping the upstream Github Actions up to date within the Anura Github Actions. This does nothing until Dependabot is turned on for this repository and with this configuration in place Dependabot will only take a stance on Github Actions versioning  and nothing else.