### PR TITLE
Fix compiler warning about condition always being true

### DIFF
--- a/src/kre/Texture.cpp
+++ b/src/kre/Texture.cpp
@@ -391,10 +391,14 @@ namespace KRE
 				tp.filtering[0] = min;
 				tp.filtering[1] = max;
 				tp.filtering[2] = mip;
+
 				// If you enable bilinear/trilinear/aniso filtering on an image then it must have mipmaps.
-				if((min != Texture::Filtering::LINEAR || min != Texture::Filtering::ANISOTROPIC
-					|| max == Texture::Filtering::LINEAR || max == Texture::Filtering::ANISOTROPIC
-					|| mip == Texture::Filtering::LINEAR) && tp.mipmaps == 0) {
+				if((min == Texture::Filtering::LINEAR
+				 || min == Texture::Filtering::ANISOTROPIC
+				 || max == Texture::Filtering::LINEAR
+				 || max == Texture::Filtering::ANISOTROPIC
+				 || mip == Texture::Filtering::LINEAR
+				) && tp.mipmaps == 0) {
 					tp.mipmaps = 2;
 				}
 			}
@@ -404,9 +408,12 @@ namespace KRE
 			texture_params_[n].filtering[2] = mip;
 
 			// If you enable bilinear/trilinear/aniso filtering on an image then it must have mipmaps.
-			if((min != Texture::Filtering::LINEAR || min != Texture::Filtering::ANISOTROPIC
-				|| max == Texture::Filtering::LINEAR || max == Texture::Filtering::ANISOTROPIC
-				|| mip == Texture::Filtering::LINEAR) && texture_params_[n].mipmaps == 0) {
+			if((min == Texture::Filtering::LINEAR
+			 || min == Texture::Filtering::ANISOTROPIC
+			 || max == Texture::Filtering::LINEAR
+			 || max == Texture::Filtering::ANISOTROPIC
+			 || mip == Texture::Filtering::LINEAR
+			) && texture_params_[n].mipmaps == 0) {
 				texture_params_[n].mipmaps = 2;
 			}
 		}


### PR DESCRIPTION
LLVM reports thusly:
```
src/kre/Texture.cpp:407:42: error: overlapping comparisons always evaluate to true [-Werror,-Wtautological-overlap-compare]
                        if((min != Texture::Filtering::LINEAR || min != Texture::Filtering::ANISOTROPIC
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/kre/Texture.cpp:395:43: error: overlapping comparisons always evaluate to true [-Werror,-Wtautological-overlap-compare]
                                if((min != Texture::Filtering::LINEAR || min != Texture::Filtering::ANISOTROPIC
                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I don't know this code, but judging by the comments it feels like changing these to equality checks is the right way to go. Would like a second opinion.