### PR TITLE
Declare explicit linker deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ endif
 # Linker library options.
 LIBS := $(shell pkg-config --libs x11 gl ) \
 	$(shell pkg-config --libs $(MANDATORY_LIBS)) \
-	 -logg -lvorbis -lvorbisfile -lrt -lstdc++
+	 -logg -lvorbis -lvorbisfile -lrt -lstdc++ -lm
 
 # libvpx check
 USE_LIBVPX?=$(shell pkg-config --exists vpx && echo yes)

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ endif
 # Linker library options.
 LIBS := $(shell pkg-config --libs x11 gl ) \
 	$(shell pkg-config --libs $(MANDATORY_LIBS)) \
-	 -logg -lvorbis -lvorbisfile -lrt
+	 -logg -lvorbis -lvorbisfile -lrt -lstdc++
 
 # libvpx check
 USE_LIBVPX?=$(shell pkg-config --exists vpx && echo yes)


### PR DESCRIPTION
The recent iterative work on getting a CI going has exposed that modern linkers, such as LLD, want one to be more explicit about the full set of things to be linked in.

Added `libstdc++` and `libm` as explicit linker dependencies.