### PR TITLE
	modified:   src/filesystem.cpp

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -218,7 +218,7 @@ namespace sys
 
 	void copy_file(const std::string& from, const std::string& to)
 	{
-		copy_file(path(from), path(to), copy_option::fail_if_exists);
+		copy_file(path(from), path(to), copy_options::none);
 	}
 
 	void rmdir_recursive(const std::string& fpath)


### PR DESCRIPTION
When building on Arch it would throw an error describing that `copy_option` is deprecated and `copy_options` should be used instead, however `copy_options` does not have a `fail_if_exists` member so it is replaced with `none`.