### PR TITLE
fixed uncompatibility with older version of boost

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -218,7 +218,11 @@ namespace sys
 
 	void copy_file(const std::string& from, const std::string& to)
 	{
-		copy_file(path(from), path(to), copy_options::none);
+		#if BOOST_VERSION < 107400
+			copy_file(path(from), path(to), copy_option::fail_if_exists);
+		#else
+			copy_file(path(from), path(to), copy_options::none);
+		#endif
 	}
 
 	void rmdir_recursive(const std::string& fpath)


### PR DESCRIPTION
My previous commit accommodated the newer version of boost, disregarding the older ones still being used today, so this fixes that and makes it possible to build on Ubuntu versions older than 22.04.