### PR TITLE
Musl compatibility

### DIFF
--- a/src/asserts.cpp
+++ b/src/asserts.cpp
@@ -27,9 +27,11 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include "StackWalker.h"
-#else
+#elif defined(__GLIBC__)
 #include <csignal>
 #include "stacktrace.hpp"
+#else
+#include <csignal>
 #endif
 
 #ifndef NO_EDITOR
@@ -205,7 +207,7 @@ void output_backtrace()
 #ifdef _MSC_VER
 	StderrStackWalker sw;
 	sw.ShowCallstack();
-#else
+#elif defined(__GLIBC__)
 // disable C++ stack traces for now.
 //	const int nframes = 256;
 //	void* trace_buffer[nframes];

--- a/src/sys.cpp
+++ b/src/sys.cpp
@@ -99,6 +99,7 @@ namespace sys
 	}
 	}
 
+#ifdef __GLIBC__
 	bool get_memory_consumption(MemoryConsumptionInfo* info)
 	{
 		std::string s = read_file("/proc/self/status");
@@ -125,6 +126,16 @@ namespace sys
 	int get_heap_object_usable_size(void* ptr) {
 		return malloc_usable_size(ptr);
 	}
+#else
+	bool get_memory_consumption(MemoryConsumptionInfo* info)
+	{
+		return false;
+	}
+
+	int get_heap_object_usable_size(void* ptr) {
+		return 0;
+	}
+#endif
 
 #elif defined(__APPLE__)
 


### PR DESCRIPTION
Based on feedback by al1f in discord, hide use of glibc-specific functions behind `defined(__GLIBC__)` checks.

The stacktrace printing could be reactivated using [libexecinfo](https://github.com/resslinux/libexecinfo) (making this an optional dependency, or just vendoring it in, it looks like it could benefit from C++ templates), but that's out of scope for this PR.