### PR TITLE
Add level.speech_dialog_is_active, which returns true if there's a speech dialog visible.

### DIFF
--- a/src/level.cpp
+++ b/src/level.cpp
@@ -3860,6 +3860,9 @@ DEFINE_SET_FIELD
 		}
 	}
 
+DEFINE_FIELD(speech_dialog_is_active, "bool")
+	return variant::from_bool(obj.current_speech_dialog() != nullptr);
+
 DEFINE_FIELD(id, "string")
 	return variant(obj.id_);
 


### PR DESCRIPTION
Closes issue 96.