### PR TITLE
Change all build triggers to be PR + merge queue

### DIFF
--- a/.github/workflows/push-unit-tests-dynamic-linux.yaml
+++ b/.github/workflows/push-unit-tests-dynamic-linux.yaml
@@ -1,5 +1,7 @@
 name: Unit Tests / Required / Dynamic / Linux
-on: push
+on:
+  pull_request:
+  merge_group:
 
 jobs:
   test:


### PR DESCRIPTION
This is unfortunate, but turns out `on: push` is not a thing for builds from forks. We have to trigger everything on pull requests and merge queue events.