### PR TITLE
Level title is shown on Ctrl-p pause menu.

### DIFF
--- a/src/level_runner.cpp
+++ b/src/level_runner.cpp
@@ -740,7 +740,8 @@ extern bool g_enable_graphical_fonts;
 void LevelRunner::show_pause_title()
 {
 	if(!editor_ && g_enable_graphical_fonts) {
-		set_scene_title("Paused\n\n\n(ctrl-p)", paused ? std::numeric_limits<int>::max() : 25);
+		// The height of a line break is less than that of a line with text. Hence the extra '\n's
+		set_scene_title(lvl_->title() + "\n\n\n\nPaused\n\n\n(ctrl-p)", paused ? std::numeric_limits<int>::max() : 25);
 	}
 }
 


### PR DESCRIPTION
 It would be better if the text of the label was centered though.

Fixes https://github.com/frogatto/frogatto/issues/615

![image](https://github.com/anura-engine/anura/assets/104121665/5c20e97d-4e7e-4005-aa7e-38747bc13bd3)
