### PR TITLE
Let Dependabot be its own biggest fan and automerge GHA changes

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/.github/workflows"
     schedule:
-      interval: "monthly"
+      interval: "daily"

--- a/.github/workflows/pr-dependabot-auto-approve.yaml
+++ b/.github/workflows/pr-dependabot-auto-approve.yaml
@@ -1,0 +1,17 @@
+name: Dependabot Auto Approve
+
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot-auto-approve:
+    runs-on: ubuntu-22.04
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Auto Approve Dependabot PRs
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: gh pr review --approve "$PR_URL"

--- a/.github/workflows/pr-dependabot-auto-merge.yaml
+++ b/.github/workflows/pr-dependabot-auto-merge.yaml
@@ -1,0 +1,18 @@
+name: Dependabot Auto Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-auto-merge:
+    runs-on: ubuntu-22.04
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Enable Auto Merge for Dependabot PRs
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
* Switch cadence on checking for GHA updates to daily
* Let Dependabot autoapprove its own PRs
* Let Dependabot flag its own PRs as automergeable

Nothing will merge in a red state anyway, so this is safe. Less manual churn to keep the CI machinery itself up to date.