### PR TITLE
Catch the Windows build up to imgui having moved

### DIFF
--- a/windows/anura.vcxproj
+++ b/windows/anura.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\imgui\imgui.h" />
+    <ClInclude Include="..\src\imgui\imgui.h" />
     <ClInclude Include="..\src\achievements.hpp" />
     <ClInclude Include="..\src\animation_creator.hpp" />
     <ClInclude Include="..\src\animation_preview_widget.hpp" />
@@ -397,12 +397,8 @@
     <None Include="..\src\kre\geometry.inl" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\imgui\imgui.cpp">
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">IMGUI_INCLUDE_IMGUI_USER_INL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">IMGUI_INCLUDE_IMGUI_USER_INL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
-    <ClCompile Include="..\imgui\imgui_draw.cpp" />
-    <ClCompile Include="..\imgui\imgui_widgets.cpp" />
+    <ClCompile Include="..\src\imgui\imgui_draw.cpp" />
+    <ClCompile Include="..\src\imgui\imgui_widgets.cpp" />
     <ClCompile Include="..\src\achievements.cpp" />
     <ClCompile Include="..\src\animation_creator.cpp" />
     <ClCompile Include="..\src\animation_preview_widget.cpp" />

--- a/windows/anura.vcxproj.filters
+++ b/windows/anura.vcxproj.filters
@@ -1176,7 +1176,7 @@
     <ClInclude Include="..\src\kre\imgui_impl_sdl_gl3.h">
       <Filter>Header Files\kre</Filter>
     </ClInclude>
-    <ClInclude Include="..\imgui\imgui.h">
+    <ClInclude Include="..\src\imgui\imgui.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\src\theme_imgui.hpp">
@@ -2191,10 +2191,10 @@
     <ClCompile Include="..\src\kre\ParticleSystemUI.cpp">
       <Filter>Source Files\kre</Filter>
     </ClCompile>
-    <ClCompile Include="..\imgui\imgui.cpp">
+    <ClCompile Include="..\src\imgui\imgui.cpp">
       <Filter>Source Files\kre</Filter>
     </ClCompile>
-    <ClCompile Include="..\imgui\imgui_draw.cpp">
+    <ClCompile Include="..\src\imgui\imgui_draw.cpp">
       <Filter>Source Files\kre</Filter>
     </ClCompile>
     <ClCompile Include="..\src\kre\imgui_impl_sdl_gl3.cpp">
@@ -2206,7 +2206,7 @@
     <ClCompile Include="..\src\variant_type_check.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\imgui\imgui_widgets.cpp">
+    <ClCompile Include="..\src\imgui\imgui_widgets.cpp">
       <Filter>Source Files\kre</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
When I ripped the Windows and macOS changes out of the mega PR, seems I ripped just slightly too much out.