### PR TITLE
Explicity set TZ to UTC for the steamos build to avoid apt interactivity

### DIFF
--- a/.github/workflows/pr-unit-tests-static-linux.yaml
+++ b/.github/workflows/pr-unit-tests-static-linux.yaml
@@ -28,6 +28,7 @@ jobs:
       - name: Install Dependencies
         env:
           DEBIAN_FRONTEND: noninteractive
+          TZ: UTC
         run: |
           sudo apt-get -qq update
           sudo apt-get -qq upgrade -y


### PR DESCRIPTION
Currently the SteamOS builds get stack waiting for human input when the build upgrades tzdata in the container.