### PR TITLE
Use a heavier hammer to set apt noninteractive with sudo

### DIFF
--- a/.github/workflows/pr-unit-tests-dynamic-linux.yaml
+++ b/.github/workflows/pr-unit-tests-dynamic-linux.yaml
@@ -15,9 +15,8 @@ jobs:
           - Debug
     steps:
       - name: Install Dependencies
-        env:
-          DEBIAN_FRONTEND: noninteractive
         run: |
+          sudo dpkg-reconfigure debconf --frontend=noninteractive
           sudo apt-get -qq update
           sudo apt-get -qq upgrade -y
           sudo apt-get -qq install -y --no-install-recommends \

--- a/.github/workflows/pr-unit-tests-static-linux.yaml
+++ b/.github/workflows/pr-unit-tests-static-linux.yaml
@@ -26,9 +26,8 @@ jobs:
     container: registry.gitlab.steamos.cloud/steamrt/${{ matrix.steam-runtime }}/sdk
     steps:
       - name: Install Dependencies
-        env:
-          DEBIAN_FRONTEND: noninteractive
         run: |
+          sudo dpkg-reconfigure debconf --frontend=noninteractive
           sudo apt-get -qq update
           sudo apt-get -qq upgrade -y
           sudo apt-get -qq install -y --no-install-recommends \


### PR DESCRIPTION
So far we got lucky no package in any of the apt-get installs or upgrades needed manual input.