### PR TITLE
Explicitly manually set UTC as localtime in SteamOS builds

### DIFF
--- a/.github/workflows/pr-unit-tests-static-linux.yaml
+++ b/.github/workflows/pr-unit-tests-static-linux.yaml
@@ -29,6 +29,8 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
+          sudo ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+          sudo dpkg-reconfigure --frontend=noninteractive tzdata
           sudo apt-get -qq update
           sudo apt-get -qq upgrade -y
           sudo apt-get -qq install -y --no-install-recommends \


### PR DESCRIPTION
Seems `tzdata` handling in `dpkg` has some historical quirks and warts we're now managing to hit with the SteamOS SDK image at package upgrade time.

Setting localtime manually ahead of time gets rid of the install time need for human interaction on the `critical` `debconfig` question.