### PR TITLE
Globally define GLM_ENABLE_EXPERIMENTAL for dynamic linux builds

### DIFF
--- a/.github/workflows/pr-smoketest-debian.yaml
+++ b/.github/workflows/pr-smoketest-debian.yaml
@@ -10,7 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         debian:
-          # Bullseye is the oldest Debian with a new enough glm
+          # Buster is the oldest Debian with repositories still alive upstream
+          - "buster" # 10
           - "bullseye" # 11
           - "bookworm" # 12
           # 13 Trixie is expected in 2025-06

--- a/.github/workflows/pr-smoketest-fedora.yaml
+++ b/.github/workflows/pr-smoketest-fedora.yaml
@@ -10,6 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         fedora:
+          # Fedora 30 is the oldest Fedora shipping with dnf out of the box
+          - "30"
           - "31"
           - "32"
           - "33"

--- a/.github/workflows/pr-smoketest-fedora.yaml
+++ b/.github/workflows/pr-smoketest-fedora.yaml
@@ -20,9 +20,10 @@ jobs:
           - "38"
           - "39"
           - "40"
-          # 40 is expected in 2024-04
-          # 41 is expected in 2024-11
+          - "41"
           # 42 is expected in 2025-04
+          # 43 is expected in 2025-11
+          # 44 is expected in 2026-04
         compiler:
           - g++
           - clang++

--- a/.github/workflows/pr-smoketest-fedora.yaml
+++ b/.github/workflows/pr-smoketest-fedora.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         fedora:
-          # 32 is the oldest Fedora with a new enough glm
+          - "31"
           - "32"
           - "33"
           - "34"

--- a/.github/workflows/pr-smoketest-ubuntu.yaml
+++ b/.github/workflows/pr-smoketest-ubuntu.yaml
@@ -11,6 +11,8 @@ jobs:
       matrix:
         # Versions between LTS are not available for long - we only do LTS
         ubuntu:
+          # 20.04 is the oldest LTS with a new enough glibc for the node 20
+          # runtime backing the upstream default checkout action
           - "20.04"
           - "22.04"
           - "24.04"

--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ On Pull Requests:
     * 22.04 / Jammy Jellyfish
     * 24.04 / Noble Numbat
   * Fedora
+    * 30
     * 31
     * 32
     * 33

--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ On Pull Requests:
     * 22.04 / Jammy Jellyfish
     * 24.04 / Noble Numbat
   * Fedora
+    * 31
     * 32
     * 33
     * 34

--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ On Pull Requests:
 
 * Smoketest dynamic builds on Linux (both g++ and clang++)
   * Debian
+    * 10 / Buster
     * 11 / Bullseye
     * 12 / Bookworm
   * Ubuntu

--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ On Pull Requests:
     * 38
     * 39
     * 40
+    * 41
   * Rocky Linux
     * 8
     * 9

--- a/buildsystem/cmake-includes/silence-warnings/03-all/clang/02-reorder-ctor/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/03-all/clang/02-reorder-ctor/CMakeLists.txt
@@ -4,1200 +4,1200 @@
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/ColorTransform.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/ParticleSystemWidget.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/SceneObjectCallable.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/TextureObject.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/achievements.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/animation_creator.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/animation_preview_widget.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/animation_widget.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/anura_shader.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/asserts.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/auto_update_window.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/background.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/bar_widget.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/blur.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/border_widget.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/button.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/cairo.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/character_editor_dialog.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/checkbox.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/checksum.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_dialog.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_widget.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/collision_utils.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/color_picker.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/compress.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/controls.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/controls_dialog.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/current_generator.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_callable.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_dialog.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_type.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/db_client.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/debug_console.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/dialog.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/difficulty.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/distortion.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/drag_widget.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/draw_primitive.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/draw_scene.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/draw_tile.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/dropdown_widget.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/editor_dialogs.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/editor_formula_functions.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/editor_layers_dialog.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/editor_level_properties_dialog.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/editor_module_properties_dialog.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/editor_stats_dialog.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/editor_variable_info.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/entity.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/external_text_editor.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/ffl_dom.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/ffl_lib.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/file_chooser_dialog.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/formula.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/formula_callable.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/formula_callable_definition.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/formula_callable_visitor.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/formula_constants.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/formula_function_registry.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/formula_garbage_collector.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/formula_interface.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/formula_internal.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/formula_object.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/formula_profiler.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/formula_test.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/formula_variable_storage.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/formula_visualize_widget.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/formula_vm.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/framed_gui_element.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/ft_iface.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/game_registry.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/geometry_callable.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font_label.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/grid_widget.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/group_property_editor_dialog.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_loader.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_map.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_mask.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_renderable.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_tile.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/hex/tile_rules.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/http_client.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/http_server.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/i18n.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/image_widget.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/joystick.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/json_parser.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/key_button.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/kre/AttributeSet.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blittable.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/kre/CameraObject.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDeviceOGL.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/kre/EffectsOGL.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSTB.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/kre/LightObject.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystem.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemAffectors.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemEmitters.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemParameters.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemUI.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderTarget.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/kre/Renderable.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneNode.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneObject.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneTree.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/kre/ShadersOGL.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/kre/WindowManager.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/label.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/language_dialog.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/layout_widget.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/level.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/level_logic.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/level_object.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/level_runner.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/light.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/load_level_nothread.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/loading_screen.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/main.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/module.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/module_web_server.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/multi_tile_pattern.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/object_events.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/particle_system.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/particle_system_proxy.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/pathfinding.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/pause_game_dialog.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/playable_custom_object.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/player_info.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/poly_line_widget.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/poly_map.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/preferences.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/preprocessor.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/preview_tileset_widget.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/progress_bar.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/property_editor_dialog.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/rich_text_label.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/scrollable_widget.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/scrollbar_widget.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/segment_editor_dialog.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/shared_memory_pipe.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/slider.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/speech_dialog.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/stats.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/stats_server.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/surface_cache.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/surface_palette.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_container.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_element.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_paint.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_parse.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_path_parse.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_shapes.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_style.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/tbs_ai_player.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/tbs_bot.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/tbs_client.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/tbs_functions.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/tbs_game.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_client.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_server.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/tbs_ipc_client.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/tbs_matchmaking_server.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/tbs_relay_server.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server_base.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/tbs_web_server.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/theme_imgui.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/tile_map.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tmx_reader.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/tileset_editor_dialog.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/tooltip.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/tree_view_widget.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/utility_object_compiler.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/utility_query.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/utility_render_level.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/utils.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/variant.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/variant_callable.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/variant_type.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/variant_utils.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/video_selections.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/water.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/water_particle_system.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/weather_particle_system.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/widget.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/widget_factory.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/wml_formula_callable.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_lexer.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_parser.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_element.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xslider.cpp"
     APPEND_STRING
-    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor"
+    PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )

--- a/buildsystem/linux-dynamic/CMakeLists.txt
+++ b/buildsystem/linux-dynamic/CMakeLists.txt
@@ -162,6 +162,10 @@ endif()
 # XXX - imgui_custom.cpp relies on these
 add_compile_definitions(IMGUI_DEFINE_MATH_OPERATORS)
 
+# Quaternions have become experimental in GLM???
+# XXX - Newer versions of GLM need this for some reason
+add_compile_definitions(GLM_ENABLE_EXPERIMENTAL)
+
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     # Older compilers should not trip up when we selectively silence warnings
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-warning-option")


### PR DESCRIPTION
For whatever reason, our old code now needs to globally define `GLM_ENABLE_EXPERIMENTAL` to work with a newer version of GLM in the build system. This does not appear to break any older builds, but still flagged it with an `XXX` as a potentially unoptimal thing to eventually get rid of. In fact it oddly enough re-enabled some of our previously broken builds.

Used this opportunity to also seek out and better document the tail end  limits of the CI system.

Builds enabled by this:

* Fedora 30
* Fedora 31
* Fedora 41
* Debian 10 / Buster

Buillds potentially enabled by this, but not in the CI:

* Ubuntu 18.04 and older
  * The glibc shipped there is too old for node 20 and modern GHA, like checkout, run on that
* Fedora 29 and older
  * Fedora does not ship the `dnf` package manager per default in versions older than 30
* Debian 9 and older
  * The minimal Docker image points at a mirror out of the box, which has been archived since
* RHEL 7 and older based distros, like CentOS / Scientific Linux / Oracle Linux
  * RHEL quasi abandoned the old CentOS model
  * We cover Rocky and Alma from 8 onwards instead of bothering with the past

And for the sake of completeness: older SuSe Leap versions are broken for reasons unrelated to GLM.

I will not commit to complicating the build system any further to allow for continuously testing for the very long tail of distribution support as one would start needing per era or per version tricks in the build matrix and the correct thing for users on those versions is to switch to a newer OS and move on.