### PR TITLE
Bump GHA runners to Ubuntu 24.04

### DIFF
--- a/.github/workflows/pr-dependabot-auto-approve.yaml
+++ b/.github/workflows/pr-dependabot-auto-approve.yaml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   dependabot-auto-approve:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Auto Approve Dependabot PRs

--- a/.github/workflows/pr-dependabot-auto-merge.yaml
+++ b/.github/workflows/pr-dependabot-auto-merge.yaml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   dependabot-auto-merge:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Enable Auto Merge for Dependabot PRs

--- a/.github/workflows/pr-smoketest-debian.yaml
+++ b/.github/workflows/pr-smoketest-debian.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   test:
     name: Compilers
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-smoketest-fedora.yaml
+++ b/.github/workflows/pr-smoketest-fedora.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   test:
     name: Compilers
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-smoketest-opensuse-leap.yaml
+++ b/.github/workflows/pr-smoketest-opensuse-leap.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   test:
     name: Compilers
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-smoketest-ubuntu.yaml
+++ b/.github/workflows/pr-smoketest-ubuntu.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   test:
     name: Compilers
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-unit-tests-dynamic-linux.yaml
+++ b/.github/workflows/pr-unit-tests-dynamic-linux.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   test:
     name: Ubuntu
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-unit-tests-static-linux.yaml
+++ b/.github/workflows/pr-unit-tests-static-linux.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: Build and Test in Steam SDK
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -77,7 +77,7 @@ jobs:
   test:
     name: Test on Steam Platform
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
GitHub released the new runners end of October. They are marginally faster, so we might as well benefit from them.