### PR TITLE
tried to make the engine retain the user selected resolution

### DIFF
--- a/src/preference_data.hpp
+++ b/src/preference_data.hpp
@@ -1,0 +1,13 @@
+#ifndef PREFERENCE_DATA
+#define PREFERENCE_DATA
+
+#include <string>
+
+struct PreferenceData{
+    int resolution_width;
+    int resolution_height;
+    bool error = false;
+    std::string error_message = "";
+};
+
+#endif

--- a/src/preferences.hpp
+++ b/src/preferences.hpp
@@ -28,6 +28,7 @@
 
 #include "uri.hpp"
 #include "variant.hpp"
+#include "preference_data.hpp"
 
 namespace game_logic
 {
@@ -204,7 +205,7 @@ namespace preferences
 
 	game_logic::FormulaCallable* registry();
 
-	void load_preferences();
+	PreferenceData load_preferences();
 	void save_preferences();
 
 	uri::uri get_tbs_uri();


### PR DESCRIPTION
I changed 3 files and created preference_data.hpp. You should be weary of my lack of knowledge about how Frogatto treats it's virtual gamescreen sizes. Basically I added an if statement that separates presence and absence of a preferences.cfg. If the file exists, the autoSelectResolution function is not called, because why should the resolution be set automatically when user defined settings exist? Please notify me if my changes require further explanation.
Also here's a video showing off the changes.
https://youtu.be/Wueo7ppIjr0