### PR TITLE
Add a smoketest build for Rocky Linux

### DIFF
--- a/.github/workflows/pr-smoketest-rocky.yaml
+++ b/.github/workflows/pr-smoketest-rocky.yaml
@@ -1,0 +1,79 @@
+name: Smoketest / Informative / Rocky
+on:
+  pull_request:
+
+jobs:
+  test:
+    name: Compilers
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        rocky:
+          # 8 is the oldest Rocky Linux to exist
+          - "8"
+          - "9"
+          # 10 is expected in 2025-05
+          # 11 is expected in 2028-05
+          # 12 is expected in 2031-05
+        compiler:
+          - g++
+          - clang++
+        build-type:
+          - Release
+          - Debug
+    container: rockylinux:${{ matrix.rocky }}
+    steps:
+      - name: Install Dependencies
+        run: |
+            dnf -qy update
+            # We need to add an extra command to DNF to manage its config
+            dnf install -qy 'dnf-command(config-manager)'
+            # We need either PowerTools or CodeReady Builder
+            # Rocky 8 has PowerTools, Rocky 9 has CodeReady Builder
+            dnf config-manager --set-enabled powertools || dnf config-manager --set-enabled crb
+            # We need packages from EPEL
+            dnf install -qy epel-release
+            dnf install -qy \
+              git \
+              cmake \
+              gcc-c++ \
+              clang \
+              ccache \
+              boost-devel \
+              zlib-devel \
+              mesa-libGL-devel \
+              glew-devel \
+              freetype-devel \
+              glm-devel \
+              SDL2-devel \
+              SDL2_image-devel \
+              SDL2_mixer-devel \
+              SDL2_ttf-devel \
+              libogg-devel \
+              libvorbis-devel \
+              cairo-devel
+
+      - name: Checkout Anura
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+            submodules: true
+
+      - name: Set ccache up
+        uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5 # v1.2.17
+        with:
+          key: ${{ github.job }}-rocky-${{ matrix.rocky }}-${{ matrix.compiler }}-${{ matrix.build-type }}
+
+      - name: Build Prep Anura
+        run: |
+          cmake buildsystem/linux-dynamic \
+          -D CMAKE_CXX_COMPILER="${{ matrix.compiler }}" \
+          -D CMAKE_BUILD_TYPE="${{ matrix.build-type }}"
+
+      - name: Build Anura
+        run: |
+          # Compile with number of available hyperthreads
+          make -j "$(getconf _NPROCESSORS_ONLN)"
+
+      - name: Run Unit Tests
+        run: ./anura --tests

--- a/README.md
+++ b/README.md
@@ -259,6 +259,12 @@ Check the
 [CI](https://github.com/anura-engine/anura/blob/trunk/.github/workflows/pr-smoketest-fedora.yaml)
 out and repeat after it what it is doing.
 
+#### Rocky Linux
+
+Check the
+[CI](https://github.com/anura-engine/anura/blob/trunk/.github/workflows/pr-smoketest-rocky.yaml)
+out and repeat after it what it is doing.
+
 #### openSUSE Leap
 
 Check the
@@ -340,6 +346,9 @@ On Pull Requests:
     * 38
     * 39
     * 40
+  * Rocky Linux
+    * 8
+    * 9
   * openSUSE Leap
     * 15.4
     * 15.5

--- a/buildsystem/cmake-includes/modules/FindRT.cmake
+++ b/buildsystem/cmake-includes/modules/FindRT.cmake
@@ -1,20 +1,55 @@
-# Try to find real time libraries
-# Once done, this will define
+# - Check for the presence of RT
 #
-# RT_FOUND - system has rt library
-# RT_LIBRARIES - rt libraries directory
-#
-# Source: https://gitlab.cern.ch/dss/eos/commit/44070e575faaa46bd998708ef03eedb381506ff0
-#
+# The following variables are set when RT is found:
+#  HAVE_RT       = Set to true, if all components of RT
+#                          have been found.
+#  RT_INCLUDES   = Include path for the header files of RT
+#  RT_LIBRARIES  = Link these to use RT
 
-if(RT_LIBRARIES)
-    set(RT_FIND_QUIETLY TRUE)
-endif(RT_LIBRARIES)
+## -----------------------------------------------------------------------------
+## Check for the header files
 
-find_library(RT_LIBRARY rt)
-set(RT_LIBRARIES ${RT_LIBRARY})
-# handle the QUIETLY and REQUIRED arguments and set
-# RT_FOUND to TRUE if all listed variables are TRUE
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(RT DEFAULT_MSG RT_LIBRARY)
-mark_as_advanced(RT_LIBRARY)
+find_path (RT_INCLUDES time.h
+  PATHS /usr/local/include /usr/include
+  )
+
+## -----------------------------------------------------------------------------
+## Check for the library
+
+find_library (RT_LIBRARIES rt
+  PATHS /usr/local/lib /usr/lib /lib
+  )
+
+## -----------------------------------------------------------------------------
+## Actions taken when all components have been found
+
+if (RT_INCLUDES AND RT_LIBRARIES)
+  set (HAVE_RT TRUE)
+else (RT_INCLUDES AND RT_LIBRARIES)
+  if (NOT RT_FIND_QUIETLY)
+    if (NOT RT_INCLUDES)
+      message (STATUS "Unable to find RT header files!")
+    endif (NOT RT_INCLUDES)
+    if (NOT RT_LIBRARIES)
+      message (STATUS "Unable to find RT library files!")
+    endif (NOT RT_LIBRARIES)
+  endif (NOT RT_FIND_QUIETLY)
+endif (RT_INCLUDES AND RT_LIBRARIES)
+
+if (HAVE_RT)
+  if (NOT RT_FIND_QUIETLY)
+    message (STATUS "Found components for RT")
+    message (STATUS "RT_INCLUDES = ${RT_INCLUDES}")
+    message (STATUS "RT_LIBRARIES = ${RT_LIBRARIES}")
+  endif (NOT RT_FIND_QUIETLY)
+else (HAVE_RT)
+  if (RT_FIND_REQUIRED)
+    message (FATAL_ERROR "Could not find RT!")
+  endif (RT_FIND_REQUIRED)
+endif (HAVE_RT)
+
+mark_as_advanced (
+  HAVE_RT
+  RT_LIBRARIES
+  RT_INCLUDES
+  )

--- a/buildsystem/cmake-includes/silence-warnings/01-default/clang/03-deprecated-declarations/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/01-default/clang/03-deprecated-declarations/CMakeLists.txt
@@ -2,6 +2,42 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/LayerBlitInfo.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/ParticleSystemWidget.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/TextureObject.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/animation_creator.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/animation_preview_widget.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/animation_widget.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/anura_shader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
@@ -14,7 +50,37 @@ set_property(
 )
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/auto_update_window.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/background.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/bar_widget.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/blur.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/border_widget.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
@@ -32,13 +98,43 @@ set_property(
 )
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/checkbox.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_widget.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/collision_utils.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/color_picker.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/controls_dialog.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/current_generator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
@@ -86,6 +182,18 @@ set_property(
 )
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/distortion.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/drag_widget.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/draw_primitive.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
@@ -98,7 +206,25 @@ set_property(
 )
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/draw_tile.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/dropdown_widget.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/editor_dialogs.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
@@ -140,6 +266,12 @@ set_property(
 )
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/external_text_editor.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/ffl_dom.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
@@ -158,7 +290,19 @@ set_property(
 )
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/formula_constants.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/formula_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
@@ -170,7 +314,43 @@ set_property(
 )
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/formula_visualize_widget.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/framed_gui_element.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/geometry_callable.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font_label.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/grid_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
@@ -182,13 +362,379 @@ set_property(
 )
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/gui_section.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_helper.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_loader.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_mask.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_renderable.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_tile.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/hex/tile_rules.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/image_widget.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/input.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/json_parser.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/key_button.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/AttributeSet.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blend.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blittable.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CameraObject.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Canvas.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CanvasOGL.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ClipScope.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ClipScopeOGL.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Color.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Cursor.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDevice.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDeviceOGL.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/EffectsOGL.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FboOGL.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Font.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontDriver.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontFreetype.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSDL.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSTB.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Gradients.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/LightObject.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystem.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemAffectors.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemEmitters.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemUI.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderQueue.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderTarget.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Renderable.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneGraph.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneNode.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneObject.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneTree.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Scissor.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ScissorOGL.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Shaders.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ShadersOGL.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/StencilScope.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Surface.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceBlur.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceSDL.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceScale.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/TexPack.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Texture.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/TextureOGL.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/UniformBufferOGL.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraph.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraphCairo.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/kre/WindowManager.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/label.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/language_dialog.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/layout_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
@@ -206,6 +752,12 @@ set_property(
 )
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/level_object.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/level_runner.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
@@ -218,7 +770,19 @@ set_property(
 )
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/light.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/load_level_nothread.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/loading_screen.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
@@ -230,7 +794,37 @@ set_property(
 )
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/message_dialog.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/module.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/multi_tile_pattern.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system_proxy.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
@@ -242,7 +836,31 @@ set_property(
 )
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/pause_game_dialog.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/playable_custom_object.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/player_info.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/poly_line_widget.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/poly_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
@@ -254,7 +872,61 @@ set_property(
 )
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/preview_tileset_widget.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/progress_bar.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/property_editor_dialog.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/rect_renderable.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/rectangle_rotator.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/rich_text_label.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/screen_handling.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/scrollable_widget.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/scrollbar_widget.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/settings_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
@@ -266,13 +938,49 @@ set_property(
 )
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/slider.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/solid_map.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/speech_dialog.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/stats.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/surface_cache.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/surface_palette.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/surface_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
@@ -309,6 +1017,12 @@ set_property(
 
 set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_gradient.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_paint.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
@@ -356,6 +1070,12 @@ set_property(
 )
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/tile_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
@@ -380,6 +1100,24 @@ set_property(
 )
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/tooltip.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/tree_view_widget.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/utility_object_compiler.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/utility_render_level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
@@ -398,6 +1136,12 @@ set_property(
 )
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/variant_type.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/video_selections.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
@@ -410,7 +1154,151 @@ set_property(
 )
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/water_particle_system.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/weather_particle_system.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/widget.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/widget_factory.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_parser.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_properties.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_selector.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_styles.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_stylesheet.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_transition.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/event_listener.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/scrollable.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/solid_renderable.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_absolute_box.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_background_info.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_block_box.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_border_info.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_box.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_element.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_block_box.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_element_box.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_layout_engine.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_line_box.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_listitem_box.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
@@ -422,7 +1310,43 @@ set_property(
 )
 
 set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_render_ctx.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_root_box.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_script_interface.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_style_tree.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_box.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
     SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_node.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xslider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )

--- a/buildsystem/cmake-includes/silence-warnings/01-default/clang/04-enum-constexpr-conversion/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/01-default/clang/04-enum-constexpr-conversion/CMakeLists.txt
@@ -1,0 +1,14 @@
+# In an optimal state, this file does not exist
+# XXX - The leading spaces in this file are meaningful for string concatenation!
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/module_web_server.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-enum-constexpr-conversion"
+)
+
+set_property(
+    SOURCE "${CMAKE_BINARY_DIR}/src/stats_web_server.cpp"
+    APPEND_STRING
+    PROPERTY COMPILE_FLAGS " -Wno-enum-constexpr-conversion"
+)

--- a/buildsystem/cmake-includes/silence-warnings/01-default/clang/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/01-default/clang/CMakeLists.txt
@@ -3,3 +3,4 @@
 include("${CMAKE_CURRENT_LIST_DIR}/01-cxx-11-narrowing/CMakeLists.txt")
 include("${CMAKE_CURRENT_LIST_DIR}/02-unused-result/CMakeLists.txt")
 include("${CMAKE_CURRENT_LIST_DIR}/03-deprecated-declarations/CMakeLists.txt")
+include("${CMAKE_CURRENT_LIST_DIR}/04-enum-constexpr-conversion/CMakeLists.txt")

--- a/buildsystem/linux-dynamic/CMakeLists.txt
+++ b/buildsystem/linux-dynamic/CMakeLists.txt
@@ -78,7 +78,7 @@ find_package(GLEW REQUIRED)
 # https://cmake.org/cmake/help/v3.12/module/FindFreetype.html
 find_package(Freetype REQUIRED)
 
-# https://github.com/assimp/assimp/blob/60989a598e2eec923612597b1516604b816d404a/cmake-modules/FindRT.cmake
+# https://github.com/shadow/shadow/blob/aa0445f42d4b5413b27b27d267d0a7f3ec29bed1/cmake/FindRT.cmake
 find_package(RT REQUIRED)
 # https://chromium.googlesource.com/external/github.com/g-truc/glm/+/refs/heads/0.9.6/util/FindGLM.cmake
 find_package(GLM REQUIRED)


### PR DESCRIPTION
Missed the CentOS replacements having spawned in the RHEL universe.

Here is the binary compatible one.

* Added a build for Rocky Linux 8
  * A lot more deprecation warnings raised by clang++
* Added a build for Rocky Linux 9
  * A scary compiler warning silenced on http server modules: https://github.com/llvm/llvm-project/issues/59036
  * A new implementation of `FindRT.cmake` was vendored in as upstream RHEL 9 moved glibc-adjacent things around a bit: https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/considerations_in_adopting_rhel_9/index#ref_changes-to-dotnet_assembly_compilers-and-development-tools