### PR TITLE
Fix boost::filesystem includes

### DIFF
--- a/src/auto_update_window.cpp
+++ b/src/auto_update_window.cpp
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <sstream>
 
+#include <boost/filesystem/exception.hpp>
 #include <boost/filesystem/operations.hpp>
 
 #include <GL/glew.h>

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -23,6 +23,7 @@
 
 #include <deque>
 
+#include <boost/filesystem/exception.hpp>
 #include <boost/filesystem/operations.hpp>
 
 #include "asserts.hpp"


### PR DESCRIPTION
Directly include <boost/filesystem/filesystem_error.hpp>. In previous versions, this may have been implicitly included through <boost/filesystem/operations.hpp>.