### PR TITLE
Add a smoketest build for openSUSE Leap 16.0

### DIFF
--- a/.github/workflows/pr-smoketest-opensuse-leap.yaml
+++ b/.github/workflows/pr-smoketest-opensuse-leap.yaml
@@ -19,8 +19,9 @@ jobs:
           - "15.4"
           - "15.5"
           - "15.6"
-          # 15.7 is expected in 2025-06
-          # 15.8 is expected in 2026-06
+          - "16.0"
+          # 16.1 is expected in 2026-06
+          # 16.2 is expected in 2027-06
         compiler:
           - g++
           - clang++

--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ On Pull Requests:
     * 15.4
     * 15.5
     * 15.6
+    * 16.0
 
 This set should cover most popular use cases and also derivative distributions
 of these root distributions. There are no plans to test on rolling release


### PR DESCRIPTION
Putting this already in place as it is expected to be available sometime in Autumn 2025.