### PR TITLE
Boost updates

### DIFF
--- a/.github/workflows/pr-smoketest-debian.yaml
+++ b/.github/workflows/pr-smoketest-debian.yaml
@@ -10,8 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         debian:
-          # Buster is the oldest Debian with repositories still alive upstream
-          - "buster" # 10
+          # Bullseye is the oldest Debian with repositories still alive upstream
           - "bullseye" # 11
           - "bookworm" # 12
           # 13 Trixie is expected in 2025-06

--- a/README.md
+++ b/README.md
@@ -338,7 +338,6 @@ On Pull Requests:
 
 * Smoketest dynamic builds on Linux (both g++ and clang++)
   * Debian
-    * 10 / Buster
     * 11 / Bullseye
     * 12 / Bookworm
   * Ubuntu

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -36,12 +36,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#if BOOST_VERSION <= 105600
-//Avoid link error on Linux when compiling with -std=c++0x and linking with
-//a Boost lib not compiled with these flags.
-#define BOOST_NO_SCOPED_ENUMS
-#define BOOST_NO_CXX11_SCOPED_ENUMS
-#endif
 #endif
 
 #include <boost/filesystem.hpp>

--- a/src/formula_function.cpp
+++ b/src/formula_function.cpp
@@ -5707,8 +5707,9 @@ std::map<std::string, variant>& get_doc_cache(bool prefs_dir) {
 		const std::string& s = v.as_string();
 		boost::uuids::detail::sha1 hash;
 		hash.process_bytes(s.c_str(), s.length());
-		unsigned int digest[5];
-		hash.get_digest(digest);
+		boost::uuids::detail::sha1::digest_type digest_boost;
+		hash.get_digest(digest_boost);
+		auto *digest = reinterpret_cast<uint32_t*>(digest_boost);
 		std::stringstream str;
 		for(int n = 0; n < 5; ++n) {
 			str << std::hex << std::setw(8) << std::setfill('0') << digest[n];

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -32,15 +32,14 @@
 
 PREF_INT(http_fake_lag, 0, "fake lag to add to http requests");
 
-http_client::http_client(const std::string& host, const std::string& port, int session, boost::asio::io_service* service)
+http_client::http_client(const std::string& host, const std::string& port, int session, boost::asio::io_context* context)
   : session_id_(session),
-    io_service_buf_(service ? nullptr : new boost::asio::io_service),
-	io_service_(service ? service : io_service_buf_.get()),
+    io_context_buf_(context ? nullptr : new boost::asio::io_context),
+	io_context_(context ? context : io_context_buf_.get()),
 	resolution_state_(RESOLUTION_NOT_STARTED),
-    resolver_(new tcp::resolver(*io_service_)),
+	resolver_(new tcp::resolver(*io_context_)),
 	host_(host),
 	port_(port),
-	resolver_query_(new tcp::resolver::query(tcp::resolver::query::protocol_type::v4(), host.c_str(), port.c_str())),
 	in_flight_(0),
 	allow_keepalive_(false),
 	timeout_and_retry_(false)
@@ -84,7 +83,7 @@ void http_client::send_request(std::string method_path, std::string request, std
 		conn->retry_fn = std::bind(&http_client::send_request, this, method_path, request, handler, error_handler, progress_handler, num_retries, attempt_num+1);
 		conn->retry_on_error = num_retries+1;
 	} else {
-		conn.reset(new Connection(*io_service_));
+		conn.reset(new Connection(*io_context_));
 		conn->retry_on_error = num_retries;
 		if(num_retries || timeout_and_retry_) {
 			conn->retry_fn = std::bind(&http_client::send_request, this, method_path, request, handler, error_handler, progress_handler, num_retries-1, attempt_num+1);
@@ -110,7 +109,7 @@ void http_client::send_request(std::string method_path, std::string request, std
 		resolution_state_ = RESOLUTION_IN_PROGRESS;
 
 		try {
-			resolver_->async_resolve(*resolver_query_,
+			resolver_->async_resolve(host_, port_,
 				std::bind(&http_client::handle_resolve, this,
 					std::placeholders::_1,
 					std::placeholders::_2,
@@ -126,7 +125,7 @@ void http_client::send_request(std::string method_path, std::string request, std
 	}
 }
 
-void http_client::handle_resolve(const boost::system::error_code& error, tcp::resolver::iterator endpoint_iterator, connection_ptr conn)
+void http_client::handle_resolve(const boost::system::error_code& error, tcp::resolver::results_type endpoint_result, connection_ptr conn)
 {
 	if(conn->aborted) {
 		return;
@@ -134,7 +133,7 @@ void http_client::handle_resolve(const boost::system::error_code& error, tcp::re
 
 	if(!error)
 	{
-		endpoint_iterator_ = endpoint_iterator;
+		endpoint_result_ = endpoint_result;
 		// Attempt a connection to each endpoint in the list until we
 		// successfully establish a connection.
 		async_connect(conn);
@@ -153,15 +152,15 @@ void http_client::async_connect(connection_ptr conn)
 
 	try {
 		boost::asio::async_connect(*conn->socket,
-			endpoint_iterator_,
+			endpoint_result_,
 			std::bind(&http_client::handle_connect, this,
-				std::placeholders::_1, conn, endpoint_iterator_));
+				std::placeholders::_1, std::placeholders::_2, conn));
 	} catch(const std::exception& e) {
 		LOG_ERROR("Error in async_connect: " << e.what() << "\n");
 	}
 }
 
-void http_client::handle_connect(const boost::system::error_code& error, connection_ptr conn, tcp::resolver::iterator resolve_itor)
+void http_client::handle_connect(const boost::system::error_code& error, tcp::endpoint endpoint, connection_ptr conn)
 {
 	if(conn->aborted) {
 		return;
@@ -169,21 +168,12 @@ void http_client::handle_connect(const boost::system::error_code& error, connect
 
 	if(error) {
 		LOG_WARN("HANDLE_CONNECT_ERROR: " << error);
-		if(endpoint_iterator_ == resolve_itor) {
-			++endpoint_iterator_;
-		}
-		//ASSERT_LOG(endpoint_iterator_ != tcp::resolver::iterator(), "COULD NOT RESOLVE TBS SERVER: " << resolve_itor->endpoint().address().to_string() << ":" << resolve_itor->endpoint().port());
-		if(endpoint_iterator_ == tcp::resolver::iterator()) {
-			resolution_state_ = RESOLUTION_NOT_STARTED;
-			--in_flight_;
-			conn->error_handler("Error establishing connection");
-			return;
-		}
-
-		async_connect(conn);
-
+		resolution_state_ = RESOLUTION_NOT_STARTED;
+		--in_flight_;
+		conn->error_handler("Error establishing connection");
 		return;
 	}
+
 #if defined(_MSC_VER)
 	conn->socket->set_option(boost::asio::ip::tcp::no_delay(true));
 #endif
@@ -483,8 +473,8 @@ void http_client::process()
 	}
 
 	try {
-		io_service_->poll();
-		io_service_->reset();
+		io_context_->poll();
+		io_context_->restart();
 	} catch(const std::exception& e) {
 		LOG_ERROR("Error in http client: " << e.what() << "\n");
 	}

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -152,16 +152,10 @@ void http_client::async_connect(connection_ptr conn)
 	}
 
 	try {
-#if BOOST_VERSION >= 104700
 		boost::asio::async_connect(*conn->socket,
 			endpoint_iterator_,
 			std::bind(&http_client::handle_connect, this,
 				std::placeholders::_1, conn, endpoint_iterator_));
-#else
-		conn->socket->async_connect(*endpoint_iterator_,
-			std::bind(&http_client::handle_connect, this,
-				std::placeholders::_1, conn, endpoint_iterator_));
-#endif
 	} catch(const std::exception& e) {
 		LOG_ERROR("Error in async_connect: " << e.what() << "\n");
 	}

--- a/src/http_client.hpp
+++ b/src/http_client.hpp
@@ -44,7 +44,7 @@ namespace http
 class http_client : public game_logic::FormulaCallable
 {
 public:
-	http_client(const std::string& host, const std::string& port, int session=-1, boost::asio::io_service* service=nullptr);
+	http_client(const std::string& host, const std::string& port, int session=-1, boost::asio::io_context* context=nullptr);
 	~http_client();
 	void send_request(std::string method_path,
 	                  std::string request,
@@ -64,11 +64,11 @@ private:
 	DECLARE_CALLABLE(http_client)
 	int session_id_;
 
-	std::shared_ptr<boost::asio::io_service> io_service_buf_;
-	boost::asio::io_service* io_service_;
+	std::shared_ptr<boost::asio::io_context> io_context_buf_;
+	boost::asio::io_context* io_context_;
 
 	struct Connection {
-		explicit Connection(boost::asio::io_service& serv) : socket(new tcp::socket(serv)), nbytes_sent(0), expected_len(-1), retry_on_error(0), timeout_deadline(-1), timeout_period(-1), timeout_nbytes_needed(-1), aborted(false)
+		explicit Connection(boost::asio::io_context& ctx) : socket(new tcp::socket(ctx)), nbytes_sent(0), expected_len(-1), retry_on_error(0), timeout_deadline(-1), timeout_period(-1), timeout_nbytes_needed(-1), aborted(false)
 		{}
 		explicit Connection(std::shared_ptr<tcp::socket> sock) : socket(sock), nbytes_sent(0), expected_len(-1), retry_on_error(0), timeout_deadline(-1), timeout_period(-1), timeout_nbytes_needed(-1), aborted(false)
 		{}
@@ -100,8 +100,8 @@ private:
 
 	void send_connection_request(connection_ptr conne);
 
-	void handle_resolve(const boost::system::error_code& err, tcp::resolver::iterator endpoint_iterator, connection_ptr conn);
-	void handle_connect(const boost::system::error_code& error, connection_ptr conn, tcp::resolver::iterator resolve_itor);
+	void handle_resolve(const boost::system::error_code& err, tcp::resolver::results_type endpoint_result, connection_ptr conn);
+	void handle_connect(const boost::system::error_code& error, tcp::endpoint endpoint, connection_ptr conn);
 	void write_connection_data(connection_ptr conn);
 	void handle_send(connection_ptr conn, const boost::system::error_code& e, size_t nbytes, std::shared_ptr<std::string> buf_ptr);
 	void handle_receive(connection_ptr conn, const boost::system::error_code& e, size_t nbytes);
@@ -117,8 +117,7 @@ private:
 	RESOLUTION_STATE resolution_state_;
 
 	std::shared_ptr<tcp::resolver> resolver_;
-	std::shared_ptr<tcp::resolver::query> resolver_query_;
-	tcp::resolver::iterator endpoint_iterator_;
+	tcp::resolver::results_type endpoint_result_;
 	std::string host_, port_;
 
 	int in_flight_;

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -52,14 +52,13 @@ namespace http
 		typedef web_server::socket_ptr socket_ptr;
 	}
 	struct WebServerProxyInfo {
-		WebServerProxyInfo(web_server& server, uint32_t session_id, boost::asio::io_service& io_service, const std::string& host, const std::string& port);
+		WebServerProxyInfo(web_server& server, uint32_t session_id, boost::asio::io_context& io_context, const std::string& host, const std::string& port);
 		web_server* server;
 		uint32_t session_id;
 		std::string host;
 		std::string port;
 		std::shared_ptr<tcp::resolver> resolver;
-		std::shared_ptr<tcp::resolver::query> resolver_query;
-		tcp::resolver::iterator endpoint_iterator;
+		tcp::resolver::results_type endpoint_result;
 		socket_ptr socket;
 	};
 
@@ -82,8 +81,8 @@ namespace http
 		void handle_proxy_connect(WebServerProxyInfoPtr info, const boost::system::error_code& error)
 		{
 			if(error) {
-				++(info->endpoint_iterator);
-				proxy_connect(info);
+				LOG_ERROR("Failed to connect to proxy: " << info->host);
+				return;
 			} else {
 				std::shared_ptr<std::string> msg(new std::string);
 				msg->resize(4);
@@ -95,20 +94,15 @@ namespace http
 
 		void proxy_connect(WebServerProxyInfoPtr info)
 		{
-			if(info->endpoint_iterator == tcp::resolver::iterator()) {
-				LOG_ERROR("Failed to connect to proxy: " << info->host);
-				return;
-			}
-
 			boost::asio::async_connect(info->socket->socket,
-			  info->endpoint_iterator,
+			  info->endpoint_result,
 			  std::bind(&handle_proxy_connect, info, std::placeholders::_1));
 		}
 
-		void handle_resolve_proxy(WebServerProxyInfoPtr info, const boost::system::error_code& error, tcp::resolver::iterator endpoint_iterator)
+		void handle_resolve_proxy(WebServerProxyInfoPtr info, const boost::system::error_code& error, tcp::resolver::results_type endpoint_result)
 		{
 			if(!error) {
-				info->endpoint_iterator = endpoint_iterator;
+				info->endpoint_result = endpoint_result;
 				proxy_connect(info);
 
 			} else {
@@ -116,33 +110,32 @@ namespace http
 			}
 		}
 
-		std::shared_ptr<WebServerProxyInfo> create_web_server_proxy(web_server& server_, uint32_t session_id_, boost::asio::io_service& io_service_, const std::string& host_, const std::string& port_)
+		std::shared_ptr<WebServerProxyInfo> create_web_server_proxy(web_server& server_, uint32_t session_id_, boost::asio::io_context& io_context_, const std::string& host_, const std::string& port_)
 		{
-			std::shared_ptr<WebServerProxyInfo> result(new WebServerProxyInfo(server_, session_id_,io_service_, host_, port_));
-			result->resolver->async_resolve(*result->resolver_query,
+			std::shared_ptr<WebServerProxyInfo> result(new WebServerProxyInfo(server_, session_id_,io_context_, host_, port_));
+			result->resolver->async_resolve(host_, port_,
 		  	   std::bind(handle_resolve_proxy, result, std::placeholders::_1, std::placeholders::_2));
 			return result;
 		}
 	}
 
-	WebServerProxyInfo::WebServerProxyInfo(web_server& server_, uint32_t session_id_, boost::asio::io_service& io_service_, const std::string& host_, const std::string& port_)
+	WebServerProxyInfo::WebServerProxyInfo(web_server& server_, uint32_t session_id_, boost::asio::io_context& io_context_, const std::string& host_, const std::string& port_)
 	  : server(&server_), session_id(session_id_), host(host_), port(port_),
-	    resolver(new tcp::resolver(io_service_)),
-		resolver_query(new tcp::resolver::query(tcp::resolver::query::protocol_type::v4(), host_.c_str(), port_.c_str())),
-		socket(new web_server::SocketInfo(io_service_))
+	    resolver(new tcp::resolver(io_context_)),
+		socket(new web_server::SocketInfo(io_context_))
 	{
 	}
 
-	web_server::SocketInfo::SocketInfo(boost::asio::io_service& service)
-	  : socket(service), client_version(0), supports_deflate(false)
+	web_server::SocketInfo::SocketInfo(boost::asio::io_context& context)
+	  : socket(context), client_version(0), supports_deflate(false)
 	{
 	}
 
-	web_server::web_server(boost::asio::io_service& io_service, int port)
-	  : io_service_(io_service)
+	web_server::web_server(boost::asio::io_context& io_context, int port)
+	  : io_context_(io_context)
 	{
 		if(port) {
-			acceptor_.reset(new boost::asio::ip::tcp::acceptor(io_service, tcp::endpoint(tcp::v4(), port)));
+			acceptor_.reset(new boost::asio::ip::tcp::acceptor(io_context, tcp::endpoint(tcp::v4(), port)));
 			boost::asio::socket_base::reuse_address option(true);
 			acceptor_->set_option(option);
 		}
@@ -163,7 +156,7 @@ namespace http
 
 	void web_server::connect_proxy(uint32_t session_id, const std::string& host, const std::string& port)
 	{
-		std::shared_ptr<WebServerProxyInfo> proxy = create_web_server_proxy(*this, session_id, io_service_, host, port);
+		std::shared_ptr<WebServerProxyInfo> proxy = create_web_server_proxy(*this, session_id, io_context_, host, port);
 		proxies_.push_back(proxy);
 
 	}
@@ -174,7 +167,7 @@ namespace http
 			return;
 		}
 
-		socket_ptr socket(new SocketInfo(io_service_));
+		socket_ptr socket(new SocketInfo(io_context_));
 		acceptor_->async_accept(socket->socket, std::bind(&web_server::handle_accept, this, socket, std::placeholders::_1));
 	}
 
@@ -278,7 +271,7 @@ namespace http
 	{
 		for(auto& p : proxies_) {
 			if(p->socket == socket) {
-				p->socket.reset(new SocketInfo(io_service_));
+				p->socket.reset(new SocketInfo(io_context_));
 				proxy_connect(p);
 				break;
 			}
@@ -419,7 +412,7 @@ namespace http
 	{
 		for(auto& p : proxies_) {
 			if(p->socket == socket) {
-				p->socket.reset(new SocketInfo(io_service_));
+				p->socket.reset(new SocketInfo(io_context_));
 				proxy_connect(p);
 				break;
 			}
@@ -490,7 +483,7 @@ namespace {
 using namespace http;
 class test_web_server : public http::web_server {
 public:
-	test_web_server(boost::asio::io_service& io_service) : web_server(io_service) {}
+	test_web_server(boost::asio::io_context& io_context) : web_server(io_context) {}
 	void handlePost(socket_ptr socket, variant doc, const environment& env, const std::string& raw_msg) override {
 
 		send_msg(socket, "text/json", "{ \"type\": \"ok\" }", "");
@@ -506,9 +499,9 @@ private:
 COMMAND_LINE_UTILITY(test_http_server) {
 	using namespace http;
 
-	boost::asio::io_service io_service;
-	test_web_server server(io_service);
+	boost::asio::io_context io_context;
+	test_web_server server(io_context);
 
 
-	io_service.run();
+	io_context.run();
 }

--- a/src/http_server.hpp
+++ b/src/http_server.hpp
@@ -42,7 +42,7 @@ namespace http
 	public:
 
 		struct SocketInfo {
-			explicit SocketInfo(boost::asio::io_service& service);
+			explicit SocketInfo(boost::asio::io_context& context);
 			boost::asio::ip::tcp::socket socket;
 			int client_version;
 			bool supports_deflate;
@@ -51,7 +51,7 @@ namespace http
 		typedef std::shared_ptr<SocketInfo> socket_ptr;
 		typedef std::shared_ptr<std::array<char, 64*1024> > buffer_ptr;
 
-		explicit web_server(boost::asio::io_service& io_service, int port=23456);
+		explicit web_server(boost::asio::io_context& io_context, int port=23456);
 		virtual ~web_server();
 
 		void connect_proxy(uint32_t session_id, const std::string& host, const std::string& port);
@@ -97,7 +97,7 @@ namespace http
 
 		virtual variant parse_message(const std::string& msg) const;
 
-		boost::asio::io_service& io_service_;
+		boost::asio::io_context& io_context_;
 		std::shared_ptr<boost::asio::ip::tcp::acceptor> acceptor_;
 	};
 }

--- a/src/module_web_server.cpp
+++ b/src/module_web_server.cpp
@@ -48,9 +48,9 @@
 
 using boost::asio::ip::tcp;
 
-ModuleWebServer::ModuleWebServer(const std::string& data_path, const std::string& chunk_path, boost::asio::io_service& io_service, int port)
-	: http::web_server(io_service, port),
-	timer_(io_service),
+ModuleWebServer::ModuleWebServer(const std::string& data_path, const std::string& chunk_path, boost::asio::io_context& io_context, int port)
+	: http::web_server(io_context, port),
+	timer_(io_context),
 	nheartbeat_(0),
 	data_path_(data_path),
 	chunk_path_(chunk_path),
@@ -679,7 +679,7 @@ COMMAND_LINE_UTILITY(module_server)
 	}
 
 	const assert_recover_scope recovery;
-	boost::asio::io_service io_service;
-	ModuleWebServer server(path, chunk_path, io_service, port);
-	io_service.run();
+	boost::asio::io_context io_context;
+	ModuleWebServer server(path, chunk_path, io_context, port);
+	io_context.run();
 }

--- a/src/module_web_server.hpp
+++ b/src/module_web_server.hpp
@@ -31,7 +31,7 @@
 class ModuleWebServer : public http::web_server
 {
 public:
-	explicit ModuleWebServer(const std::string& data_path, const std::string& chunk_path, boost::asio::io_service& io_service, int port=23456);
+	explicit ModuleWebServer(const std::string& data_path, const std::string& chunk_path, boost::asio::io_context& io_context, int port=23456);
 	virtual ~ModuleWebServer()
 	{}
 private:

--- a/src/multiplayer.cpp
+++ b/src/multiplayer.cpp
@@ -52,7 +52,7 @@ namespace multiplayer
 {
 	namespace
 	{
-		std::shared_ptr<boost::asio::io_service> asio_service;
+		std::shared_ptr<boost::asio::io_context> asio_context;
 		std::shared_ptr<tcp::socket> tcp_socket;
 		std::shared_ptr<udp::socket> udp_socket;
 		std::shared_ptr<udp::endpoint> udp_endpoint;
@@ -93,7 +93,7 @@ namespace multiplayer
 	Manager::Manager(bool activate)
 	{
 		if(activate) {
-			asio_service.reset(new boost::asio::io_service);
+			asio_context.reset(new boost::asio::io_context);
 		}
 	}
 
@@ -101,21 +101,20 @@ namespace multiplayer
 		udp_endpoint.reset();
 		tcp_socket.reset();
 		udp_socket.reset();
-		asio_service.reset();
+		asio_context.reset();
 		player_slot = 0;
 	}
 
 	void setup_networked_game(const std::string& server)
 	{
-		boost::asio::io_service& io_service = *asio_service;
-		tcp::resolver resolver(io_service);
+		boost::asio::io_context& io_context = *asio_context;
+		tcp::resolver resolver(io_context);
 
-		tcp::resolver::query query(server, "17002");
+		tcp::resolver::results_type endpoints = resolver.resolve(server, "17002");
+		tcp::resolver::results_type::iterator endpoint_iterator = endpoints.begin();
+		tcp::resolver::results_type::iterator end = endpoints.end();
 
-		tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
-		tcp::resolver::iterator end;
-
-		tcp_socket.reset(new tcp::socket(io_service));
+		tcp_socket.reset(new tcp::socket(io_context));
 		tcp::socket& socket = *tcp_socket;
 		boost::system::error_code error = boost::asio::error::host_not_found;
 		while(error && endpoint_iterator != end) {
@@ -144,13 +143,13 @@ namespace multiplayer
 
 		LOG_INFO("ID: " << id);
 
-		udp::resolver udp_resolver(io_service);
-		udp::resolver::query udp_query(udp::v4(), server, "17001");
+		udp::resolver udp_resolver(io_context);
 		udp_endpoint.reset(new udp::endpoint);
-		*udp_endpoint = *udp_resolver.resolve(udp_query);
+		auto udp_result = udp_resolver.resolve(udp::v4(), server, "17001");
+		*udp_endpoint = *udp_result.begin();
 		udp::endpoint& receiver_endpoint = *udp_endpoint;
 
-		udp_socket.reset(new udp::socket(io_service));
+		udp_socket.reset(new udp::socket(io_context));
 		udp_socket->open(udp::v4());
 
 		std::array<char, 4> udp_msg;
@@ -345,8 +344,8 @@ namespace multiplayer
 		ASSERT_EQ(*ptr, '\n');
 		++ptr;
 
-		boost::asio::io_service& io_service = *asio_service;
-		udp::resolver udp_resolver(io_service);
+		boost::asio::io_context& io_context = *asio_context;
+		udp::resolver udp_resolver(io_context);
 
 		udp_endpoint_peers.clear();
 
@@ -372,9 +371,9 @@ namespace multiplayer
 			LOG_INFO("SLOT " << n << " = " << host << " " << port);
 
 			udp_endpoint_peers.push_back(std::make_shared<udp::endpoint>());
-			udp::resolver::query peer_query(udp::v4(), host, port);
 
-			*udp_endpoint_peers.back() = *udp_resolver.resolve(peer_query);
+			auto udp_result = udp_resolver.resolve(udp::v4(), host, port);
+			*udp_endpoint_peers.back() = *udp_result.begin();
 
 			if(preferences::relay_through_server()) {
 				*udp_endpoint_peers.back() = *udp_endpoint;
@@ -436,8 +435,8 @@ namespace multiplayer
 
 						std::string port_str = formatter() << port;
 
-						udp::resolver::query peer_query(udp::v4(), udp_endpoint_peers[n]->address().to_string(), port_str.c_str());
-						peer_endpoint = *udp_resolver.resolve(peer_query);
+						auto udp_result = udp_resolver.resolve(udp::v4(), udp_endpoint_peers[n]->address().to_string(), port_str.c_str());
+						peer_endpoint = *udp_result.begin();
 						udp_socket->send_to(boost::asio::buffer(msg), peer_endpoint);
 					}
 				}
@@ -628,8 +627,8 @@ struct Peer {
 }
 
 COMMAND_LINE_UTILITY(hole_punch_test) {
-	boost::asio::io_service io_service;
-	udp::resolver udp_resolver(io_service);
+	boost::asio::io_context io_context;
+	udp::resolver udp_resolver(io_context);
 
 	std::string server_hostname = "wesnoth.org";
 	std::string server_port = "17001";
@@ -648,11 +647,11 @@ COMMAND_LINE_UTILITY(hole_punch_test) {
 
 	ASSERT_LOG(narg == args.size(), "wrong number of args");
 
-	udp::resolver::query udp_query(udp::v4(), server_hostname.c_str(), server_port.c_str());
 	udp::endpoint udp_endpoint;
-	udp_endpoint = *udp_resolver.resolve(udp_query);
+	auto udp_result = udp_resolver.resolve(udp::v4(), server_hostname.c_str(), server_port.c_str());
+	udp_endpoint = *udp_result.begin();
 
-	udp::socket udp_socket(io_service);
+	udp::socket udp_socket(io_context);
 	udp_socket.open(udp::v4());
 
 	udp_socket.send_to(boost::asio::buffer("hello"), udp_endpoint);
@@ -682,9 +681,9 @@ COMMAND_LINE_UTILITY(hole_punch_test) {
 				const std::string host = peers[n].host;
 				const std::string port = peers[n].port;
 				LOG_INFO("sending to " << host << " " << port);
-				udp::resolver::query peer_query(udp::v4(), host, port);
+				auto udp_result = udp_resolver.resolve(udp::v4(), host, port);
 				udp::endpoint peer_endpoint;
-				peer_endpoint = *udp_resolver.resolve(peer_query);
+				peer_endpoint = *udp_result.begin();
 
 				udp_socket.send_to(boost::asio::buffer("peer"), peer_endpoint);
 			}
@@ -693,5 +692,5 @@ COMMAND_LINE_UTILITY(hole_punch_test) {
 		}
 	}
 
-	io_service.run();
+	io_context.run();
 }

--- a/src/multiplayer_server.cpp
+++ b/src/multiplayer_server.cpp
@@ -27,11 +27,8 @@
 #include <boost/asio.hpp>
 #include <boost/regex.hpp>
 // boost::thread < 1.51 conflicts with C++11-capable compilers
-#if BOOST_VERSION < 105100
-    #include <ctime>
-    #undef TIME_UTC
-#endif
 //#include <boost/thread.hpp>
+// Should this be uncommented now?
 
 #include <iostream>
 #include <string>
@@ -66,11 +63,7 @@ namespace multiplayer
 	private:
 		void start_accept()
 		{
-#if BOOST_ASIO_VERSION >= 101400
 			socket_ptr socket(new tcp::socket(acceptor_.get_executor()));
-#else
-			socket_ptr socket(new tcp::socket(acceptor_.get_io_service()));
-#endif
 			acceptor_.async_accept(*socket, std::bind(&server::handle_accept, this, socket, std::placeholders::_1));
 		}
 

--- a/src/multiplayer_server.cpp
+++ b/src/multiplayer_server.cpp
@@ -63,7 +63,11 @@ namespace multiplayer
 	private:
 		void start_accept()
 		{
+#if BOOST_VERSION < 107000
+			socket_ptr socket(new tcp::socket(acceptor_.get_io_context()));
+#else
 			socket_ptr socket(new tcp::socket(acceptor_.get_executor()));
+#endif
 			acceptor_.async_accept(*socket, std::bind(&server::handle_accept, this, socket, std::placeholders::_1));
 		}
 

--- a/src/multiplayer_server.cpp
+++ b/src/multiplayer_server.cpp
@@ -51,10 +51,10 @@ namespace multiplayer
 	class server
 	{
 	public:
-		explicit server(boost::asio::io_service& io_service)
-		  : acceptor_(io_service, tcp::endpoint(tcp::v4(), 17002)),
+		explicit server(boost::asio::io_context& io_context)
+		  : acceptor_(io_context, tcp::endpoint(tcp::v4(), 17002)),
 			next_id_(0),
-			udp_socket_(io_service, udp::endpoint(udp::v4(), 17001))
+			udp_socket_(io_context, udp::endpoint(udp::v4(), 17001))
 		{
 			start_accept();
 			start_udp_receive();
@@ -302,8 +302,8 @@ namespace multiplayer
 
 COMMAND_LINE_UTILITY(multiplayer_server)
 {
-	boost::asio::io_service io_service;
+	boost::asio::io_context io_context;
 
-	multiplayer::server srv(io_service);
-	io_service.run();
+	multiplayer::server srv(io_context);
+	io_context.run();
 }

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -806,8 +806,9 @@ namespace preferences
 	{
 		boost::uuids::detail::sha1 hash;
 		hash.process_bytes(pword.c_str(), pword.length());
-		unsigned int digest[5];
-		hash.get_digest(digest);
+		boost::uuids::detail::sha1::digest_type digest_boost;
+		hash.get_digest(digest_boost);
+		auto *digest = reinterpret_cast<uint32_t*>(digest_boost);
 		std::stringstream str;
 		str << std::hex << std::setfill('0')  << std::setw(sizeof(unsigned int)*2) << digest[0] << digest[1] << digest[2] << digest[3] << digest[4];
 		password_ = str.str();

--- a/src/stats_server_main.cpp
+++ b/src/stats_server_main.cpp
@@ -88,7 +88,7 @@ COMMAND_LINE_UTILITY(stats_server)
 	//exception instead.
 	const assert_recover_scope recovery_scope;
 
-	boost::asio::io_service io_service;
-	web_server ws(io_service, port);
-	io_service.run();
+	boost::asio::io_context io_context;
+	web_server ws(io_context, port);
+	io_context.run();
 }

--- a/src/stats_web_server.cpp
+++ b/src/stats_web_server.cpp
@@ -42,8 +42,8 @@
 
 std::string global_debug_str;
 
-web_server::web_server(boost::asio::io_service& io_service, int port)
-	: http::web_server(io_service, port), timer_(io_service), nheartbeat_(0)
+web_server::web_server(boost::asio::io_context& io_context, int port)
+	: http::web_server(io_context, port), timer_(io_context), nheartbeat_(0)
 {
 	heartbeat();
 }

--- a/src/stats_web_server.hpp
+++ b/src/stats_web_server.hpp
@@ -28,7 +28,7 @@
 class web_server : public http::web_server
 {
 public:
-	explicit web_server(boost::asio::io_service& io_service, int port=23456);
+	explicit web_server(boost::asio::io_context& io_context, int port=23456);
 private:
 	void heartbeat();
 

--- a/src/tbs_bot.cpp
+++ b/src/tbs_bot.cpp
@@ -57,10 +57,10 @@ private:
 
 	PREF_INT(tbs_bot_delay_ms, 20, "Artificial delay for tbs bots");
 
-	bot::bot(boost::asio::io_service& service, const std::string& host, const std::string& port, variant v)
+	bot::bot(boost::asio::io_context& context, const std::string& host, const std::string& port, variant v)
   		: session_id_(v["session_id"].as_int()),
-  		  service_(service),
-  		  timer_(service),
+  		  context_(context),
+  		  timer_(context),
   		  host_(host),
   		  port_(port),
   		  script_(v["script"].as_list()),
@@ -133,7 +133,7 @@ private:
 				ipc_client_->send_request(send);
 			} else {
 				if(!client_) {
-					client_.reset(new client(host_, port_, session_id, &service_));
+					client_.reset(new client(host_, port_, session_id, &context_));
 				}
 				client_->set_use_local_cache(false);
 				client_->send_request(send, callable, std::bind(&bot::handle_response, this, std::placeholders::_1, callable));

--- a/src/tbs_bot.hpp
+++ b/src/tbs_bot.hpp
@@ -42,7 +42,7 @@ class tbs_bot_timer_proxy;
 class bot : public game_logic::FormulaCallable
 	{
 	public:
-		bot(boost::asio::io_service& io_service, const std::string& host, const std::string& port, variant v);
+		bot(boost::asio::io_context& io_context, const std::string& host, const std::string& port, variant v);
 		~bot();
 
 		void set_ipc_client(ffl::IntrusivePtr<ipc_client> ipc_client) { ipc_client_ = ipc_client; }
@@ -67,7 +67,7 @@ class bot : public game_logic::FormulaCallable
 		ffl::IntrusivePtr<client> client_;
 		ffl::IntrusivePtr<ipc_client> ipc_client_;
 
-		boost::asio::io_service& service_;
+		boost::asio::io_context& context_;
 		boost::asio::deadline_timer timer_;
 
 		game_logic::FormulaPtr on_create_, on_message_;

--- a/src/tbs_client.cpp
+++ b/src/tbs_client.cpp
@@ -40,8 +40,8 @@ namespace tbs
 	PREF_INT(tbs_fake_error_rate, 0, "Percentage error rate for tbs connections; used to debug issues");
 
 	client::client(const std::string& host, const std::string& port,
-				   int session, boost::asio::io_service* service)
-	  : http_client(host, port, session, service), use_local_cache_(g_tbs_client_prediction),
+				   int session, boost::asio::io_context* context)
+	  : http_client(host, port, session, context), use_local_cache_(g_tbs_client_prediction),
 		local_game_cache_(nullptr), local_nplayer_(-1)
 	{
 	}

--- a/src/tbs_client.hpp
+++ b/src/tbs_client.hpp
@@ -34,7 +34,7 @@ namespace tbs
 	class client : public http_client
 	{
 	public:
-		client(const std::string& host, const std::string& port, int session=-1, boost::asio::io_service* service=nullptr);
+		client(const std::string& host, const std::string& port, int session=-1, boost::asio::io_context* context=nullptr);
 
 		void send_request(variant request,
 			game_logic::MapFormulaCallablePtr callable,

--- a/src/tbs_game.cpp
+++ b/src/tbs_game.cpp
@@ -625,7 +625,7 @@ namespace {
 
 		//handleEvent("add_bot", map_into_callable(info).get());
 
-	//	ffl::IntrusivePtr<bot> new_bot(new bot(*web_server::service(), "127.0.0.1", formatter() << web_server::port(), info));
+	//	ffl::IntrusivePtr<bot> new_bot(new bot(*web_server::context(), "127.0.0.1", formatter() << web_server::port(), info));
 	//	bots_.push_back(new_bot);
 	}
 
@@ -845,12 +845,12 @@ namespace {
 					ffl::IntrusivePtr<ipc_client> cli(new ipc_client(p.second));
 
 					LOG_INFO("CREATED BOT: " << n << "/" << value.num_elements());
-					ffl::IntrusivePtr<bot> new_bot(new bot(*web_server::service(), "127.0.0.1", "23456", value[n]));
+					ffl::IntrusivePtr<bot> new_bot(new bot(*web_server::context(), "127.0.0.1", "23456", value[n]));
 					new_bot->set_ipc_client(cli);
 
 					obj.bots_.push_back(new_bot);
 				} else {
-					ffl::IntrusivePtr<bot> new_bot(new bot(*web_server::service(), "127.0.0.1", formatter() << web_server::port(), value[n]));
+					ffl::IntrusivePtr<bot> new_bot(new bot(*web_server::context(), "127.0.0.1", formatter() << web_server::port(), value[n]));
 					obj.bots_.push_back(new_bot);
 				}
 			}

--- a/src/tbs_internal_server.cpp
+++ b/src/tbs_internal_server.cpp
@@ -58,10 +58,10 @@ namespace tbs
 		internal_server_ptr server_ptr;
 	}
 
-	boost::asio::io_service internal_server::io_service_;
+	boost::asio::io_context internal_server::io_context_;
 
 	internal_server::internal_server()
-		: server_base(io_service_)
+		: server_base(io_context_)
 	{
 	}
 
@@ -522,8 +522,8 @@ void terminate_utility_process(bool* complete=nullptr)
 				session_id,
 				request);
 		}
-		io_service_.poll();
-		io_service_.reset();
+		io_context_.poll();
+		io_context_.restart();
 	}
 
 	void internal_server::queue_msg(int session_id, const std::string& msg, bool has_priority)

--- a/src/tbs_internal_server.hpp
+++ b/src/tbs_internal_server.hpp
@@ -59,7 +59,7 @@ namespace tbs
 			game_logic::MapFormulaCallablePtr callable,
 			std::function<void(const std::string&)> handler);
 		static void process();
-		static boost::asio::io_service& get_io_service() { return io_service_; }
+		static boost::asio::io_context& get_io_context() { return io_context_; }
 
 		static int requests_in_flight(int session_id);
 	protected:
@@ -70,7 +70,7 @@ namespace tbs
 			int session_id,
 			std::function<void(const std::string&)> handler,
 			game_logic::MapFormulaCallablePtr callable);
-		static boost::asio::io_service io_service_;
+		static boost::asio::io_context io_context_;
 
 		void write_queue(send_function send_fn, const variant& v, int session_id);
 		bool read_queue(send_function* send_fn, variant* v, int *session_id);

--- a/src/tbs_matchmaking_server.cpp
+++ b/src/tbs_matchmaking_server.cpp
@@ -215,10 +215,10 @@ class matchmaking_server : public game_logic::FormulaCallable, public http::web_
 {
 	struct SessionInfo;
 public:
-	matchmaking_server(boost::asio::io_service& io_service, int port)
-	  : http::web_server(io_service, port),
-	    io_service_(io_service), port_(port),
-		timer_(io_service), db_timer_(io_service),
+	matchmaking_server(boost::asio::io_context& io_context, int port)
+	  : http::web_server(io_context, port),
+	    io_context_(io_context), port_(port),
+		timer_(io_context), db_timer_(io_context),
 		time_ms_(0), send_at_time_ms_(1000), terminated_servers_(0),
 		controller_(game_logic::FormulaObject::create("matchmaking_server")),
 		status_doc_state_id_(1),
@@ -2277,7 +2277,7 @@ private:
 		send_msg(sock, "text/json", msg.write_json(), "");
 	}
 
-	boost::asio::io_service& io_service_;
+	boost::asio::io_context& io_context_;
 	int port_;
 	boost::asio::deadline_timer timer_;
 	boost::asio::deadline_timer db_timer_;
@@ -3267,9 +3267,9 @@ void process_tbs_matchmaking_server()
 {
 	int port = 23456;
 	if(g_internal_tbs_matchmaking_server) {
-		static boost::asio::io_service io_service;
-		static ffl::IntrusivePtr<matchmaking_server> server(new matchmaking_server(io_service, port));
-		io_service.poll();
+		static boost::asio::io_context io_context;
+		static ffl::IntrusivePtr<matchmaking_server> server(new matchmaking_server(io_context, port));
+		io_context.poll();
 	}
 }
 
@@ -3291,9 +3291,9 @@ COMMAND_LINE_UTILITY(tbs_matchmaking_server) {
 	}
 
 	try {
-		boost::asio::io_service io_service;
-		ffl::IntrusivePtr<matchmaking_server> server(new matchmaking_server(io_service, port));
-		io_service.run();
+		boost::asio::io_context io_context;
+		ffl::IntrusivePtr<matchmaking_server> server(new matchmaking_server(io_context, port));
+		io_context.run();
 	} catch(const RestartServerException& e) {
 #if !defined(_MSC_VER)
 		execv(e.argv[0], &e.argv[0]);
@@ -3327,8 +3327,8 @@ COMMAND_LINE_UTILITY(db_script) {
 
 	variant commands = f.execute(*callable);
 
-	boost::asio::io_service io_service;
-	ffl::IntrusivePtr<matchmaking_server> server(new matchmaking_server(io_service, 29543));
+	boost::asio::io_context io_context;
+	ffl::IntrusivePtr<matchmaking_server> server(new matchmaking_server(io_context, 29543));
 
 	server->executeCommand(commands);
 

--- a/src/tbs_relay_server.cpp
+++ b/src/tbs_relay_server.cpp
@@ -7,13 +7,8 @@
 class tbs_relay_server : public http::web_server
 {
 	struct OutgoingSocketInfo {
-#if BOOST_ASIO_VERSION >= 101400
 		explicit OutgoingSocketInfo(boost::asio::ip::tcp::socket::executor_type executor)
 		  : socket(executor)
-#else
-		explicit OutgoingSocketInfo(boost::asio::io_service& service)
-		  : socket(service)
-#endif
 		{
 		}
 
@@ -91,11 +86,7 @@ public:
 
 	void start_accept_outgoing()
 	{
-#if BOOST_ASIO_VERSION >= 101400
 		OutgoingSocketPtr socket(new OutgoingSocketInfo(acceptor_.get_executor()));
-#else
-		OutgoingSocketPtr socket(new OutgoingSocketInfo(acceptor_.get_io_service()));
-#endif
 		acceptor_.async_accept(socket->socket, std::bind(&tbs_relay_server::handle_accept_outgoing, this, socket, std::placeholders::_1));
 	}
 

--- a/src/tbs_relay_server.cpp
+++ b/src/tbs_relay_server.cpp
@@ -72,9 +72,9 @@ class tbs_relay_server : public http::web_server
 	std::map<uint32_t, SessionInfo> sessions_;
 
 public:
-	tbs_relay_server(boost::asio::io_service& io_service, int incoming_port, int outgoing_port)
-	  : http::web_server(io_service, incoming_port),
-	    acceptor_(io_service, tcp::endpoint(tcp::v4(), outgoing_port))
+	tbs_relay_server(boost::asio::io_context& io_context, int incoming_port, int outgoing_port)
+	  : http::web_server(io_context, incoming_port),
+	    acceptor_(io_context, tcp::endpoint(tcp::v4(), outgoing_port))
 	{
 		start_accept_outgoing();
 	}
@@ -261,19 +261,19 @@ COMMAND_LINE_UTILITY(tbs_relay_server)
 		}
 	}
 
-	boost::asio::io_service io_service;
+	boost::asio::io_context io_context;
 
-	tbs_relay_server server(io_service, incoming_port, outgoing_port);
+	tbs_relay_server server(io_context, incoming_port, outgoing_port);
 
-	io_service.run();
+	io_context.run();
 }
 
 namespace {
 class test_web_server : public http::web_server
 {
 public:
-	test_web_server(boost::asio::io_service& io_service, int port=23456)
-	  : http::web_server(io_service, port)
+	test_web_server(boost::asio::io_context& io_context, int port=23456)
+	  : http::web_server(io_context, port)
 	{}
 
 	void handlePost(socket_ptr socket, variant doc, const http::environment& env, const std::string& raw_msg) override
@@ -294,16 +294,16 @@ public:
 
 COMMAND_LINE_UTILITY(test_tbs_relay_server)
 {
-	boost::asio::io_service io_service;
+	boost::asio::io_context io_context;
 
-	test_web_server web_server(io_service, 23456);
+	test_web_server web_server(io_context, 23456);
 	web_server.connect_proxy(1, "localhost", "23459");
 
-	ffl::IntrusivePtr<http_client> client(new http_client("localhost", "23458", 1, &io_service));
+	ffl::IntrusivePtr<http_client> client(new http_client("localhost", "23458", 1, &io_context));
 
 	int x = 0;
 	for(int count = 0; ; ++count) {
-		io_service.poll();
+		io_context.poll();
 		usleep(100000);
 
 		if(count%10 == 0 && client->num_requests_in_flight() == 0) {

--- a/src/tbs_relay_server.cpp
+++ b/src/tbs_relay_server.cpp
@@ -7,8 +7,13 @@
 class tbs_relay_server : public http::web_server
 {
 	struct OutgoingSocketInfo {
+#if BOOST_VERSION < 107000
+		explicit OutgoingSocketInfo(boost::asio::io_context& context)
+		  : socket(context)
+#else
 		explicit OutgoingSocketInfo(boost::asio::ip::tcp::socket::executor_type executor)
 		  : socket(executor)
+#endif
 		{
 		}
 
@@ -86,7 +91,11 @@ public:
 
 	void start_accept_outgoing()
 	{
+#if BOOST_VERSION < 107000
+		OutgoingSocketPtr socket(new OutgoingSocketInfo(acceptor_.get_io_context()));
+#else
 		OutgoingSocketPtr socket(new OutgoingSocketInfo(acceptor_.get_executor()));
+#endif
 		acceptor_.async_accept(socket->socket, std::bind(&tbs_relay_server::handle_accept_outgoing, this, socket, std::placeholders::_1));
 	}
 

--- a/src/tbs_server.cpp
+++ b/src/tbs_server.cpp
@@ -85,8 +85,8 @@ namespace tbs
 	server::client_info::client_info() : nplayer(0), last_contact(0)
 	{}
 
-	server::server(boost::asio::io_service& io_service)
-	  : server_base(io_service), web_server_(nullptr)
+	server::server(boost::asio::io_context& io_context)
+	  : server_base(io_context), web_server_(nullptr)
 	{
 	}
 

--- a/src/tbs_server.hpp
+++ b/src/tbs_server.hpp
@@ -38,7 +38,7 @@ namespace tbs
 	class server : public server_base
 	{
 	public:
-		explicit server(boost::asio::io_service& io_service);
+		explicit server(boost::asio::io_context& io_context);
 		virtual ~server();
 
 		void adopt_ajax_socket(socket_ptr socket, int session_id, const variant& msg);

--- a/src/tbs_server_base.cpp
+++ b/src/tbs_server_base.cpp
@@ -48,8 +48,8 @@ namespace tbs
 		}
 	}
 
-	server_base::server_base(boost::asio::io_service& io_service)
-		: timer_(io_service), nheartbeat_(0), scheduled_write_(0), status_id_(0)
+	server_base::server_base(boost::asio::io_context& io_context)
+		: timer_(io_context), nheartbeat_(0), scheduled_write_(0), status_id_(0)
 	{
 		heartbeat(boost::asio::error::timed_out);
 	}

--- a/src/tbs_server_base.hpp
+++ b/src/tbs_server_base.hpp
@@ -35,7 +35,7 @@ namespace tbs
 	class server_base
 	{
 	public:
-		server_base(boost::asio::io_service& io_service);
+		server_base(boost::asio::io_context& io_context);
 		virtual ~server_base();
 
 		void clear_games();

--- a/src/tbs_web_server.cpp
+++ b/src/tbs_web_server.cpp
@@ -64,7 +64,7 @@ namespace tbs
 {
 	namespace
 	{
-		boost::asio::io_service* g_service;
+		boost::asio::io_context* g_context;
 		int g_listening_port = -1;
 		web_server* web_server_instance = nullptr;
 	}
@@ -73,12 +73,12 @@ namespace tbs
 
 	using boost::asio::ip::tcp;
 
-	boost::asio::io_service* web_server::service() { return g_service; }
+	boost::asio::io_context* web_server::context() { return g_context; }
 	boost::interprocess::named_semaphore* web_server::termination_semaphore() { return g_termination_semaphore; }
 	int web_server::port() { return g_listening_port; }
 
-	web_server::web_server(server& serv, boost::asio::io_service& io_service, int port)
-		: http::web_server(io_service, port), server_(serv), timer_(io_service)
+	web_server::web_server(server& serv, boost::asio::io_context& io_context, int port)
+		: http::web_server(io_context, port), server_(serv), timer_(io_context)
 	{
 		web_server_instance = this;
 		timer_.expires_from_now(boost::posix_time::milliseconds(1000));
@@ -286,12 +286,12 @@ COMMAND_LINE_UTILITY(tbs_server) {
 */
 	LOG_INFO("MONITOR URL: " << "http://localhost:" << port << "/tbs_monitor.html");
 
-	boost::asio::io_service io_service;
+	boost::asio::io_context io_context;
 
-	tbs::g_service = &io_service;
+	tbs::g_context = &io_context;
 	tbs::g_listening_port = port;
 
-	tbs::server s(io_service);
+	tbs::server s(io_context);
 
 	for(auto session : ipc_sessions) {
 		SharedMemoryPipePtr pipe(new SharedMemoryPipe(session.pipe_name, false));
@@ -302,7 +302,7 @@ COMMAND_LINE_UTILITY(tbs_server) {
 
 	boost::shared_ptr<tbs::web_server> ws;
 
-	ws.reset(new tbs::web_server(s, io_service, ipc_sessions.empty() ? port : 0));
+	ws.reset(new tbs::web_server(s, io_context, ipc_sessions.empty() ? port : 0));
 	s.set_http_server(ws.get());
 	LOG_INFO("tbs_server(): Listening on port " << std::dec << port);
 
@@ -358,7 +358,7 @@ COMMAND_LINE_UTILITY(tbs_server) {
 		try {
 			const assert_recover_scope assert_scope;
 			for(const std::string& id : bot_id) {
-				bots.push_back(ffl::IntrusivePtr<tbs::bot>(new tbs::bot(io_service, "127.0.0.1", formatter() << port, json::parse_from_file("data/tbs_test/" + id + ".cfg"))));
+				bots.push_back(ffl::IntrusivePtr<tbs::bot>(new tbs::bot(io_context, "127.0.0.1", formatter() << port, json::parse_from_file("data/tbs_test/" + id + ".cfg"))));
 			}
 		} catch(const validation_failure_exception& e) {
 			std::map<variant,variant> m;
@@ -371,7 +371,7 @@ COMMAND_LINE_UTILITY(tbs_server) {
 		}
 
 		try {
-			io_service.run();
+			io_context.run();
 		} catch(const code_modified_exception&) {
 			s.clear_games();
 		} catch(const tbs::exit_exception&) {

--- a/src/tbs_web_server.hpp
+++ b/src/tbs_web_server.hpp
@@ -32,7 +32,7 @@ namespace tbs
 	class web_server : public http::web_server
 	{
 	public:
-		static boost::asio::io_service* service();
+		static boost::asio::io_context* context();
 		static int port();
 		static boost::interprocess::named_semaphore* termination_semaphore();
 
@@ -40,7 +40,7 @@ namespace tbs
 		//happening in the server.
 		static void set_debug_state(variant v);
 
-		explicit web_server(server& serv, boost::asio::io_service& io_service, int port=23456);
+		explicit web_server(server& serv, boost::asio::io_context& io_context, int port=23456);
 		~web_server();
 	private:
 		web_server(const web_server&);


### PR DESCRIPTION
Fix build for newer boost versions. Bumps minimum required boost version to 1.66.0, with some preprocessor checks to for versions < 1.70.0.

Drop debian buster to fix CI.