### PR TITLE
fixed some full-screen related inconsistencies

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -533,10 +533,15 @@ int main(int argcount, char* argvec[])
 		module::set_core_module_name(DEFAULT_MODULE);
 	}
 
+	//This function both returns AND does stuff on the inside. Ideally the preferences
+	// would be loaded to some gullibly accessible class, but I'll keep it like this for now, despite bad practice
 	PreferenceData preference_data = preferences::load_preferences();
 
 	if(preference_data.error){
-		LOG_ERROR("Preference data error: " << preference_data.error_message);
+		//This bloody std cout statement won't show up in the terminal/CLI despite flushing, and yes
+		// I checked with a deboogaboo (debugger) something is incredibly fishy with Anura when it comes to printing/logging
+		std::cout << "Preference data error: " << preference_data.error_message << std::endl;
+		//std::cout.flush();
 	}
 
 	// load difficulty settings after module, before rest of args.
@@ -947,11 +952,9 @@ int main(int argcount, char* argvec[])
 		&& preferences::requested_window_width() == 0
 		&& preferences::requested_window_height() == 0
 	) {
-		int width = 0;
-		int height = 0;
 
 		if(!preference_data.error){
-			bool isFullscreen = preferences::get_screen_mode() != preferences::ScreenMode::WINDOWED;
+			//bool isFullscreen = preferences::get_screen_mode() != preferences::ScreenMode::WINDOWED;
 			//graphics::GameScreen::autoSelectResolution(main_wnd, preference_data.resolution_width, preference_data.resolution_height, true, isFullscreen);
 
 			preferences::adjust_virtual_width_to_match_physical(preference_data.resolution_width, preference_data.resolution_height);
@@ -959,12 +962,13 @@ int main(int argcount, char* argvec[])
 			main_wnd->setWindowSize(preference_data.resolution_width, preference_data.resolution_height);
 		}
 		else{
-			bool isFullscreen = preferences::get_screen_mode() != preferences::ScreenMode::WINDOWED;
-			graphics::GameScreen::autoSelectResolution(main_wnd, width, height, true, isFullscreen);
 
-			preferences::adjust_virtual_width_to_match_physical(width, height);
+			//Game would not be full screen if there is no valid PreferenceData struct instance
+			graphics::GameScreen::autoSelectResolution(main_wnd, preference_data.resolution_width, preference_data.resolution_height, true, false);
 
-			main_wnd->setWindowSize(width, height);
+			preferences::adjust_virtual_width_to_match_physical(preference_data.resolution_width, preference_data.resolution_height);
+
+			main_wnd->setWindowSize(preference_data.resolution_width, preference_data.resolution_height);
 		}
 	}
 
@@ -980,18 +984,25 @@ int main(int argcount, char* argvec[])
 	auto canvas = Canvas::getInstance();
 	LOG_INFO("canvas size: " << canvas->width() << "x" << canvas->height());
 
-	//WindowManager::getMainWindow()->setWindowSize(main_wnd->width(), main_wnd->height());
-
 	graphics::GameScreen::get().setDimensions(main_wnd->width(), main_wnd->height());
 	graphics::GameScreen::get().setVirtualDimensions(vw, vh);
 
-	std::cout << "Virtual dimensions: " << vw << ", " << vh << std::endl;
-	std::cout << "Screen virtual dimensions: " << graphics::GameScreen::get().getVirtualWidth() << ", " << graphics::GameScreen::get().getVirtualHeight() << std::endl;
-	std::cout << "main_wnd->width(): " << main_wnd->width() << ", " << main_wnd->height() << std::endl;
+	if(!preference_data.error){
+		if(preference_data.is_full_screen){
+			auto& gs = graphics::GameScreen::get();
+			// This changes if editor is active.
+			gs.setFullscreen(
+				preference_data.is_full_screen
+				? KRE::FullScreenMode::FULLSCREEN_WINDOWED
+				: KRE::FullScreenMode::WINDOWED
+			);
 
-	//graphics::GameScreen::get().setDimensions(preference_data.resolution_width, preference_data.resolution_height);
-	//graphics::GameScreen::get().setVirtualDimensions(preference_data.resolution_width, preference_data.resolution_height);
-	//main_wnd->setWindowIcon(module::map_file("images/window-icon.png"));
+			preferences::set_screen_mode(
+				preference_data.is_full_screen
+				? preferences::ScreenMode::FULLSCREEN_WINDOWED
+				: preferences::ScreenMode::WINDOWED);
+		}
+	}
 
 	//we prefer late swap tearing so as to minimize frame loss when possible
 	int swap_result = SDL_GL_SetSwapInterval(g_vsync != 0 ? -1 : 0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -540,7 +540,7 @@ int main(int argcount, char* argvec[])
 	if(preference_data.error){
 		//This bloody std cout statement won't show up in the terminal/CLI despite flushing, and yes
 		// I checked with a deboogaboo (debugger) something is incredibly fishy with Anura when it comes to printing/logging
-		std::cout << "Preference data error: " << preference_data.error_message << std::endl;
+		LOG_ERROR("Preference data error: " + preference_data.error_message);
 		//std::cout.flush();
 	}
 
@@ -906,8 +906,8 @@ int main(int argcount, char* argvec[])
 	variant_builder hints;
 	hints.add("renderer", "opengl");
 	hints.add("use_vsync", g_vsync != 0 ? true : false);
-	hints.add("width", preferences::requested_window_width() > 0 ? preferences::requested_window_width() : 800);
-	hints.add("height", preferences::requested_window_height() > 0 ? preferences::requested_window_height() : 600);
+	hints.add("width", preferences::cmd_requested_window_width() > 0 ? preferences::cmd_requested_window_width() : 800);
+	hints.add("height", preferences::cmd_requested_window_height() > 0 ? preferences::cmd_requested_window_height() : 600);
 	hints.add("resizeable", g_resizeable);
 	hints.add("fullscreen", preferences::get_screen_mode() != preferences::ScreenMode::WINDOWED ? true : false);
 	if(g_msaa) {
@@ -948,20 +948,21 @@ int main(int argcount, char* argvec[])
 
 	if(
 		!g_desktop_fullscreen && //Comes from a PREF_BOOL() somewhere.
+		preferences::get_screen_mode() != preferences::ScreenMode::FULLSCREEN_WINDOWED &&
 		preferences::auto_size_window()
-		&& preferences::requested_window_width() == 0
-		&& preferences::requested_window_height() == 0
+		&& preferences::cmd_requested_window_width() == 0
+		&& preferences::cmd_requested_window_height() == 0
 	) {
 
 		if(!preference_data.error){
-			//bool isFullscreen = preferences::get_screen_mode() != preferences::ScreenMode::WINDOWED;
+			//
 			//graphics::GameScreen::autoSelectResolution(main_wnd, preference_data.resolution_width, preference_data.resolution_height, true, isFullscreen);
 
 			preferences::adjust_virtual_width_to_match_physical(preference_data.resolution_width, preference_data.resolution_height);
 
 			main_wnd->setWindowSize(preference_data.resolution_width, preference_data.resolution_height);
 		}
-		else{
+		if(preference_data.error || (preference_data.resolution_width == 0 || preference_data.resolution_height == 0)){
 
 			//Game would not be full screen if there is no valid PreferenceData struct instance
 			graphics::GameScreen::autoSelectResolution(main_wnd, preference_data.resolution_width, preference_data.resolution_height, true, false);

--- a/src/preference_data.hpp
+++ b/src/preference_data.hpp
@@ -6,6 +6,7 @@
 struct PreferenceData{
     int resolution_width;
     int resolution_height;
+    bool is_full_screen;
     bool error = false;
     std::string error_message = "";
 };

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -532,8 +532,8 @@ namespace preferences
 		bool die_on_assert_ = false;
 		bool type_safety_checks_ = true;
 
-		int requested_window_width_ = 0;
-		int requested_window_height_ = 0;
+		int cmd_requested_window_width_ = 0;
+		int cmd_requested_window_height_ = 0;
 
 		PREF_BOOL(auto_size_window, true, "If true, window is auto-sized");
 		PREF_INT(virtual_window_width, 0, "Virtual width of the game window");
@@ -731,14 +731,14 @@ namespace preferences
 		g_auto_size_window = enabled;
 	}
 
-	int requested_window_width()
+	int cmd_requested_window_width()
 	{
-		return requested_window_width_;
+		return cmd_requested_window_width_;
 	}
 
-	int requested_window_height()
+	int cmd_requested_window_height()
 	{
-		return requested_window_height_;
+		return cmd_requested_window_height_;
 	}
 
 	int requested_virtual_window_width()
@@ -1067,7 +1067,7 @@ namespace preferences
         } else if(s == "--width") {
 			auto widths = util::split_into_vector_int(arg_value, ':');
 			if(widths.size() > 0) {
-				requested_window_width_ = widths[0];
+				cmd_requested_window_width_ = widths[0];
 			}
 			if(widths.size() > 1) {
 				g_virtual_window_width = widths[1];
@@ -1075,17 +1075,17 @@ namespace preferences
 				//	xypos_draw_mask = 0;
 				//}
 			} else if(!g_virtual_window_width) {
-				g_virtual_window_width = requested_window_width_;
+				g_virtual_window_width = cmd_requested_window_width_;
 			}
         } else if(s == "--height") {
 			auto heights = util::split_into_vector_int(arg_value, ':');
 			if(heights.size() > 0) {
-				requested_window_height_ = heights[0];
+				cmd_requested_window_height_ = heights[0];
 			}
 			if(heights.size() > 1) {
 				g_virtual_window_height = heights[1];
 			} else if(!g_virtual_window_height) {
-				g_virtual_window_height = requested_window_height_;
+				g_virtual_window_height = cmd_requested_window_height_;
 			}
 		} else if(s == "--no-resizable") {
 			resizable_ = false;

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -896,7 +896,7 @@ namespace preferences
 				sys::write_file(path + "preferences.cfg", module::get_default_preferences().write_json());
 				node = module::get_default_preferences();
 			} else {
-				return PreferenceData{1600,800,true,"Default preferences.cfg does not exist"};
+				return PreferenceData{1440,900,false,true,"Default preferences.cfg does not exist"};
 			}
 		}
 
@@ -904,7 +904,7 @@ namespace preferences
 			try {
 				node = json::parse_from_file(path + "preferences.cfg");
 			} catch(const json::ParseError&) {
-				return PreferenceData{1600,800,true,"Could not parse preferences.cfg"};
+				return PreferenceData{1440,900,false,true,"Could not parse preferences.cfg"};
 			}
 		}
 
@@ -966,7 +966,7 @@ namespace preferences
 
         preferences::set_32bpp_textures_if_kb_memory_at_least(512000);
 
-		return PreferenceData{node["resolution_width"].as_int(), node["resolution_height"].as_int()};
+		return PreferenceData{node["resolution_width"].as_int(), node["resolution_height"].as_int(), bool(node["is_full_screen"].as_int(0))};
 	}
 
 	void save_preferences()
@@ -1016,6 +1016,11 @@ namespace preferences
 
 		node.add("resolution_width", variant(graphics::GameScreen::get().getWidth()));
 		node.add("resolution_height", variant(graphics::GameScreen::get().getHeight()));
+
+		bool pref_full_screen = fullscreen_ == preferences::ScreenMode::WINDOWED ? false : true;
+		std::cout << "pref_full_screen: " << pref_full_screen << std::endl;
+
+		node.add("is_full_screen", variant(pref_full_screen));
 
 		std::cout << "save_preferences() :" << graphics::GameScreen::get().getWidth() << ", " << graphics::GameScreen::get().getHeight() << std::endl;
 

--- a/src/preferences.hpp
+++ b/src/preferences.hpp
@@ -163,8 +163,8 @@ namespace preferences
 
 	bool auto_size_window();
 	void set_auto_size_window(bool);
-	int requested_window_width();
-	int requested_window_height();
+	int cmd_requested_window_width();
+	int cmd_requested_window_height();
 	int requested_virtual_window_width();
 	int requested_virtual_window_height();
 	void adjust_virtual_width_to_match_physical(int width, int height);

--- a/src/screen_handling.cpp
+++ b/src/screen_handling.cpp
@@ -115,9 +115,9 @@ namespace graphics
 			if(preferences::auto_size_window() || g_desktop_fullscreen) {
 				int width = 0, height = 0;
 
-				if(preferences::requested_window_width() > 0 && preferences::requested_window_height() > 0) {
-					width = preferences::requested_window_width();
-					height = preferences::requested_window_height();
+				if(preferences::cmd_requested_window_width() > 0 && preferences::cmd_requested_window_height() > 0) {
+					width = preferences::cmd_requested_window_width();
+					height = preferences::cmd_requested_window_height();
 				} else {
 					GameScreen::autoSelectResolution(wnd, width, height, true, false);
 				}

--- a/src/video_selections.cpp
+++ b/src/video_selections.cpp
@@ -153,10 +153,31 @@ void show_video_selection_dialog()
 	// Fullscreen selection
 	bool isWindowInitiallyFullscreen = 
 		KRE::WindowManager::getMainWindow()->fullscreenMode() != KRE::FullScreenMode::WINDOWED;
+	
+	//The checkbox for setting the game to fullscreen. It takes a lambda function which changes said
+	// setting upon ticked. However, using variables that are not passed to a lambda is bad practice,
+	// I encourage future deveopers to change this /ubuntujackson
 	Checkbox* fullscreenCheckbox = new Checkbox(
 		_("Fullscreen"),
 		isWindowInitiallyFullscreen,
-		[](bool checked) { /* Do nothing here, only apply on dialog OK. */ }
+		[](bool checked) { 
+
+			auto& gs = graphics::GameScreen::get();
+			
+			//Setting fullscreen by conventional means
+			gs.setFullscreen(
+				checked
+				? KRE::FullScreenMode::FULLSCREEN_WINDOWED
+				: KRE::FullScreenMode::WINDOWED
+			);
+
+			//Always need to set preferences to reflect the actual screen settings
+			preferences::set_screen_mode(
+				checked
+				? preferences::ScreenMode::FULLSCREEN_WINDOWED
+				: preferences::ScreenMode::WINDOWED);
+
+		}
 	);
 	if(!preferences::no_fullscreen_ever()) {
 		d.addWidget(WidgetPtr(fullscreenCheckbox));
@@ -196,6 +217,7 @@ void show_video_selection_dialog()
 		
 		// Set window size.
 		if(selected_mode >= 0 && static_cast<unsigned>(selected_mode) < display_modes.size()) {
+
 			preferences::adjust_virtual_width_to_match_physical(display_modes[selected_mode].width, display_modes[selected_mode].height);
 			
 			int vw = preferences::requested_virtual_window_width() > 0
@@ -212,13 +234,5 @@ void show_video_selection_dialog()
 			}
 		}
 
-		// Actually set fullscreen.
-		KRE::WindowManager::getMainWindow()->setFullscreenMode(fullscreenCheckbox->checked()
-			? KRE::FullScreenMode::FULLSCREEN_WINDOWED
-			: KRE::FullScreenMode::WINDOWED);
-		preferences::set_screen_mode(
-			KRE::WindowManager::getMainWindow()->fullscreenMode() == KRE::FullScreenMode::WINDOWED
-				? preferences::ScreenMode::WINDOWED
-				: preferences::ScreenMode::FULLSCREEN_WINDOWED);
 	}
 }


### PR DESCRIPTION
Upon researching why you get defects like giant viewspaces and desktop environment crashes when selecting fullscreen, I found out that the shortcut in the mainfunction (main.cpp) (CTRL+F) utilises an approach which reevaluates the game's screen proportions, using the ScreenManager's utilities. In contrast, the checkbox in the video settings menu (video_selections.cpp) uses a more crude resizing mechanism, only resizing the window itself, utilising the function "void Window::setFullscreenMode(FullScreenMode mode)". My changes include additional entries in PreferenceData (preference_data.hpp), changes in saving and loading (preferences.cpp), utilising the lambda function you can pass to the checkbox constructor, triggering the fullscreen event upon clicking instead of applying it where said functionality was formerly applied. I also changed it to utilise ScreenManager::setFullscreen both at runtime, and when loading up the game in the main -function. I have also ensured that the preferences are syncted up with the full-screen configuration in both cases where fullscreen is applied, perhaps these should be bundled into one single function in the future. I also removed a few outcommented lines of code which cluttered the main function more than necessary. Also added some comments, I apologise for them not being very brief, but I don't see another way to keep track of stuff as the engine code isn't very intuitive.

Let me know if you find any issues /with kind regards, Jackson