### PR TITLE
Properly handle out of tree builds the CMake way

### DIFF
--- a/.github/workflows/pr-smoketest-alma.yaml
+++ b/.github/workflows/pr-smoketest-alma.yaml
@@ -64,13 +64,19 @@ jobs:
       - name: Build Prep Anura
         run: |
           cmake buildsystem/linux-dynamic \
-          -D CMAKE_CXX_COMPILER="${{ matrix.compiler }}" \
-          -D CMAKE_BUILD_TYPE="${{ matrix.build-type }}"
+            --preset="${{ matrix.build-type }}" \
+            -D CMAKE_CXX_COMPILER="${{ matrix.compiler }}"
 
       - name: Build Anura
         run: |
           # Compile with number of available hyperthreads
-          make -j "$(getconf _NPROCESSORS_ONLN)"
+          cmake \
+            --build buildsystem/linux-dynamic/build/"${{ matrix.build-type }}" \
+            --parallel "$(getconf _NPROCESSORS_ONLN)"
 
       - name: Run Unit Tests
-        run: ./anura --tests
+        run: |
+          ctest \
+            --output-on-failure \
+            --test-dir buildsystem/linux-dynamic/build/"${{ matrix.build-type }}" \
+            -L unittest

--- a/.github/workflows/pr-smoketest-debian.yaml
+++ b/.github/workflows/pr-smoketest-debian.yaml
@@ -10,8 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         debian:
-          # Bullseye is the oldest Debian with repositories still alive upstream
-          - "bullseye" # 11
+          # Bookworm is the oldest Debian with a new enough CMake for using presets
           - "bookworm" # 12
           - "trixie" # 13
           # 14 forky is expected in Summer 2027
@@ -66,13 +65,19 @@ jobs:
       - name: Build Prep Anura
         run: |
           cmake buildsystem/linux-dynamic \
-          -D CMAKE_CXX_COMPILER="${{ matrix.compiler }}" \
-          -D CMAKE_BUILD_TYPE="${{ matrix.build-type }}"
+            --preset="${{ matrix.build-type }}" \
+            -D CMAKE_CXX_COMPILER="${{ matrix.compiler }}"
 
       - name: Build Anura
         run: |
           # Compile with number of available hyperthreads
-          make -j "$(getconf _NPROCESSORS_ONLN)"
+          cmake \
+            --build buildsystem/linux-dynamic/build/"${{ matrix.build-type }}" \
+            --parallel "$(getconf _NPROCESSORS_ONLN)"
 
       - name: Run Unit Tests
-        run: ./anura --tests
+        run: |
+          ctest \
+            --output-on-failure \
+            --test-dir buildsystem/linux-dynamic/build/"${{ matrix.build-type }}" \
+            -L unittest

--- a/.github/workflows/pr-smoketest-fedora.yaml
+++ b/.github/workflows/pr-smoketest-fedora.yaml
@@ -61,13 +61,19 @@ jobs:
       - name: Build Prep Anura
         run: |
           cmake buildsystem/linux-dynamic \
-          -D CMAKE_CXX_COMPILER="${{ matrix.compiler }}" \
-          -D CMAKE_BUILD_TYPE="${{ matrix.build-type }}"
+            --preset="${{ matrix.build-type }}" \
+            -D CMAKE_CXX_COMPILER="${{ matrix.compiler }}"
 
       - name: Build Anura
         run: |
           # Compile with number of available hyperthreads
-          make -j "$(getconf _NPROCESSORS_ONLN)"
+          cmake \
+            --build buildsystem/linux-dynamic/build/"${{ matrix.build-type }}" \
+            --parallel "$(getconf _NPROCESSORS_ONLN)"
 
       - name: Run Unit Tests
-        run: ./anura --tests
+        run: |
+          ctest \
+            --output-on-failure \
+            --test-dir buildsystem/linux-dynamic/build/"${{ matrix.build-type }}" \
+            -L unittest

--- a/.github/workflows/pr-smoketest-opensuse-leap.yaml
+++ b/.github/workflows/pr-smoketest-opensuse-leap.yaml
@@ -63,13 +63,19 @@ jobs:
       - name: Build Prep Anura
         run: |
           cmake buildsystem/linux-dynamic \
-          -D CMAKE_CXX_COMPILER="${{ matrix.compiler }}" \
-          -D CMAKE_BUILD_TYPE="${{ matrix.build-type }}"
+            --preset="${{ matrix.build-type }}" \
+            -D CMAKE_CXX_COMPILER="${{ matrix.compiler }}"
 
       - name: Build Anura
         run: |
           # Compile with number of available hyperthreads
-          make -j "$(getconf _NPROCESSORS_ONLN)"
+          cmake \
+            --build buildsystem/linux-dynamic/build/"${{ matrix.build-type }}" \
+            --parallel "$(getconf _NPROCESSORS_ONLN)"
 
       - name: Run Unit Tests
-        run: ./anura --tests
+        run: |
+          ctest \
+            --output-on-failure \
+            --test-dir buildsystem/linux-dynamic/build/"${{ matrix.build-type }}" \
+            -L unittest

--- a/.github/workflows/pr-smoketest-rocky.yaml
+++ b/.github/workflows/pr-smoketest-rocky.yaml
@@ -64,13 +64,19 @@ jobs:
       - name: Build Prep Anura
         run: |
           cmake buildsystem/linux-dynamic \
-          -D CMAKE_CXX_COMPILER="${{ matrix.compiler }}" \
-          -D CMAKE_BUILD_TYPE="${{ matrix.build-type }}"
+            --preset="${{ matrix.build-type }}" \
+            -D CMAKE_CXX_COMPILER="${{ matrix.compiler }}"
 
       - name: Build Anura
         run: |
           # Compile with number of available hyperthreads
-          make -j "$(getconf _NPROCESSORS_ONLN)"
+          cmake \
+            --build buildsystem/linux-dynamic/build/"${{ matrix.build-type }}" \
+            --parallel "$(getconf _NPROCESSORS_ONLN)"
 
       - name: Run Unit Tests
-        run: ./anura --tests
+        run: |
+          ctest \
+            --output-on-failure \
+            --test-dir buildsystem/linux-dynamic/build/"${{ matrix.build-type }}" \
+            -L unittest

--- a/.github/workflows/pr-smoketest-ubuntu.yaml
+++ b/.github/workflows/pr-smoketest-ubuntu.yaml
@@ -66,13 +66,19 @@ jobs:
       - name: Build Prep Anura
         run: |
           cmake buildsystem/linux-dynamic \
-          -D CMAKE_CXX_COMPILER="${{ matrix.compiler }}" \
-          -D CMAKE_BUILD_TYPE="${{ matrix.build-type }}"
+            --preset="${{ matrix.build-type }}" \
+            -D CMAKE_CXX_COMPILER="${{ matrix.compiler }}"
 
       - name: Build Anura
         run: |
           # Compile with number of available hyperthreads
-          make -j "$(getconf _NPROCESSORS_ONLN)"
+          cmake \
+            --build buildsystem/linux-dynamic/build/"${{ matrix.build-type }}" \
+            --parallel "$(getconf _NPROCESSORS_ONLN)"
 
       - name: Run Unit Tests
-        run: ./anura --tests
+        run: |
+          ctest \
+            --output-on-failure \
+            --test-dir buildsystem/linux-dynamic/build/"${{ matrix.build-type }}" \
+            -L unittest

--- a/.github/workflows/pr-unit-tests-dynamic-linux.yaml
+++ b/.github/workflows/pr-unit-tests-dynamic-linux.yaml
@@ -51,13 +51,19 @@ jobs:
       - name: Build Prep Anura
         run: |
           cmake buildsystem/linux-dynamic \
-            -D CMAKE_CXX_COMPILER='clang++' \
-            -D CMAKE_BUILD_TYPE="${{ matrix.build-type }}"
+            --preset="${{ matrix.build-type }}" \
+            -D CMAKE_CXX_COMPILER="clang++"
 
       - name: Build Anura
         run: |
           # Compile with number of available hyperthreads
-          make -j "$(getconf _NPROCESSORS_ONLN)"
+          cmake \
+            --build buildsystem/linux-dynamic/build/"${{ matrix.build-type }}" \
+            --parallel "$(getconf _NPROCESSORS_ONLN)"
 
       - name: Run Unit Tests
-        run: ./anura --tests
+        run: |
+          ctest \
+            --output-on-failure \
+            --test-dir buildsystem/linux-dynamic/build/"${{ matrix.build-type }}" \
+            -L unittest

--- a/.github/workflows/pr-unit-tests-static-linux.yaml
+++ b/.github/workflows/pr-unit-tests-static-linux.yaml
@@ -67,21 +67,27 @@ jobs:
       - name: Build Prep Anura
         run: |
           cmake buildsystem/linux-steam \
-            -D CMAKE_CXX_COMPILER="${{ matrix.compiler }}" \
-            -D CMAKE_BUILD_TYPE="${{ matrix.build-type }}"
+            --preset="${{ matrix.build-type }}" \
+            -D CMAKE_CXX_COMPILER="${{ matrix.compiler }}"
 
       - name: Build Anura
         run: |
           # Compile with number of available hyperthreads
-          make -j "$(getconf _NPROCESSORS_ONLN)"
+          cmake \
+            --build buildsystem/linux-steam/build/"${{ matrix.build-type }}" \
+            --parallel "$(getconf _NPROCESSORS_ONLN)"
 
       - name: Run Unit Tests
-        run: ./anura --tests
+        run: |
+          ctest \
+            --output-on-failure \
+            --test-dir buildsystem/linux-steam/build/"${{ matrix.build-type }}" \
+            -L unittest
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: anura-static-binary-${{ matrix.build-type }}-${{ matrix.steam-runtime }}-${{ matrix.compiler }}-${{ github.sha }}
-          path: anura
+          path: buildsystem/linux-steam/build/${{ matrix.build-type }}/anura
           if-no-files-found: error
 
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,12 @@ compile_commands.json
 CTestTestfile.cmake
 _deps
 
+# Default binary directories
+buildsystem/linux-dynamic/build/Debug
+buildsystem/linux-dynamic/build/Release
+buildsystem/linux-steam/build/Debug
+buildsystem/linux-steam/build/Release
+
 # Don't commit master-config.cfg by default.
 # It should be copied or symlinked from a module.
 master-config.cfg

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ Linux operating systems.
 Sample build flow:
 
 ```bash
-cmake buildsystem/linux-dynamic -D CMAKE_CXX_COMPILER='clang++' -D CMAKE_BUILD_TYPE=Release
-make -j "$(getconf _NPROCESSORS_ONLN)"
+cmake buildsystem/linux-dynamic --preset=Debug
+cmake --build buildsystem/linux-dynamic/build/Debug --parallel "$(getconf _NPROCESSORS_ONLN)"
 ```
 
 You may not pass the compiler in via the environment variable `CXX` as that
@@ -185,6 +185,7 @@ The sets of warnings and diagnostics we currently silence:
     * [`-Wno-odr`](https://github.com/anura-engine/anura/blob/trunk/buildsystem/cmake-includes/silence-warnings/02-lto/gcc/01-odr/CMakeLists.txt)
     * [`-Wno-aggressive-loop-optimizations`](https://github.com/anura-engine/anura/blob/trunk/buildsystem/cmake-includes/silence-warnings/02-lto/gcc/02-aggressive-loop-optimizations/CMakeLists.txt)
     * [`-Wno-lto-type-mismatch`](https://github.com/anura-engine/anura/blob/trunk/buildsystem/cmake-includes/silence-warnings/02-lto/gcc/03-lto-type-mismatch/CMakeLists.txt)
+    * [`-Wno-stringpop-overflow`](https://github.com/anura-engine/anura/blob/trunk/buildsystem/cmake-includes/silence-warnings/02-lto/gcc/04-stringpop-overflow/CMakeLists.txt)
   * Clang is currently (2023-09) LTO warning free
 * `-Wall`
   * GCC
@@ -340,7 +341,6 @@ On Pull Requests:
 
 * Smoketest dynamic builds on Linux (both g++ and clang++)
   * Debian
-    * 11 / Bullseye
     * 12 / Bookworm
     * 13 / Trixie
   * Ubuntu

--- a/buildsystem/cmake-includes/silence-warnings/01-default/clang/01-cxx-11-narrowing/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/01-default/clang/01-cxx-11-narrowing/CMakeLists.txt
@@ -2,31 +2,31 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/cairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/cairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-c++11-narrowing"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-c++11-narrowing"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSDL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSDL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-c++11-narrowing"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceSDL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceSDL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-c++11-narrowing"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/md5.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/md5.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-c++11-narrowing"
 )

--- a/buildsystem/cmake-includes/silence-warnings/01-default/clang/02-unused-result/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/01-default/clang/02-unused-result/CMakeLists.txt
@@ -2,7 +2,7 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/cairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/cairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-result"
 )

--- a/buildsystem/cmake-includes/silence-warnings/01-default/clang/03-deprecated-declarations/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/01-default/clang/03-deprecated-declarations/CMakeLists.txt
@@ -2,1351 +2,1351 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/LayerBlitInfo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/LayerBlitInfo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ParticleSystemWidget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ParticleSystemWidget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/TextureObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/TextureObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_creator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_creator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_preview_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_preview_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/anura_shader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/anura_shader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/asserts.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/asserts.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/auto_update_window.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/auto_update_window.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/background.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/background.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/bar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/bar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/blur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/blur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/border_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/border_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/cairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/cairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/character_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/character_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/checkbox.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/checkbox.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/collision_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/collision_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/color_picker.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/color_picker.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/controls_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/controls_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/current_generator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/current_generator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/debug_console.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/debug_console.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/difficulty.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/difficulty.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/distortion.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/distortion.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/drag_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/drag_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_primitive.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_primitive.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_scene.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_scene.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dropdown_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dropdown_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_dialogs.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_dialogs.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_formula_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_formula_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_layers_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_layers_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_level_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_level_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_module_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_module_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_stats_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_stats_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/entity.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/entity.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/external_text_editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/external_text_editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_dom.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_dom.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/file_chooser_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/file_chooser_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/filesystem.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/filesystem.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_constants.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_constants.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_profiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_profiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_visualize_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_visualize_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/frame.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/framed_gui_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/framed_gui_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/geometry_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/geometry_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/grid_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/grid_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/group_property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/group_property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/gui_section.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/gui_section.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_helper.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_helper.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_loader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_loader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_mask.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_mask.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/tile_rules.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/tile_rules.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/image_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/image_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/input.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/input.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/json_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/json_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/key_button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/key_button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/AttributeSet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/AttributeSet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blend.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Blend.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blittable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Blittable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CameraObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CameraObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Canvas.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Canvas.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CanvasOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CanvasOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ClipScope.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ClipScope.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ClipScopeOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ClipScopeOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Color.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Color.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Cursor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Cursor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDevice.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDevice.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDeviceOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDeviceOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/EffectsOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/EffectsOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FboOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FboOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontDriver.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontDriver.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontFreetype.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontFreetype.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSDL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSDL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSTB.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSTB.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Gradients.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Gradients.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/LightObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/LightObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystem.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystem.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemAffectors.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemAffectors.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemEmitters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemEmitters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemUI.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemUI.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderQueue.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/RenderQueue.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderTarget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/RenderTarget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneGraph.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneGraph.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneNode.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneNode.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneTree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneTree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Scissor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Scissor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ScissorOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ScissorOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Shaders.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Shaders.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ShadersOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ShadersOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/StencilScope.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/StencilScope.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Surface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Surface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceBlur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceBlur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceSDL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceSDL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceScale.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceScale.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/TexPack.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/TexPack.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Texture.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Texture.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/TextureOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/TextureOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/UniformBufferOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/UniformBufferOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraph.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraph.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraphCairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraphCairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/WindowManager.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/WindowManager.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/language_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/language_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/layout_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/layout_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_logic.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_logic.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_runner.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_runner.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_solid_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_solid_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/light.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/light.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/load_level_nothread.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/load_level_nothread.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/loading_screen.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/loading_screen.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/message_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/message_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multi_tile_pattern.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multi_tile_pattern.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system_proxy.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system_proxy.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pathfinding.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pathfinding.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pause_game_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pause_game_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/playable_custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/playable_custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/player_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/player_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_line_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_line_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preferences.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preferences.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preview_tileset_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preview_tileset_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/progress_bar.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/progress_bar.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rect_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rect_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rectangle_rotator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rectangle_rotator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rich_text_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rich_text_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/screen_handling.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/screen_handling.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollable_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollable_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollbar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollbar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/settings_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/settings_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/segment_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/segment_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/slider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/slider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/solid_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/solid_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sound.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/speech_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/speech_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_cache.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_cache.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_palette.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_palette.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/easy_svg.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/easy_svg.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_attribs.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_attribs.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_container.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_container.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_fwd.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_fwd.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_gradient.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_gradient.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_paint.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_paint.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_parse.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_parse.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_path_parse.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_path_parse.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_shapes.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_shapes.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_style.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_style.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_transform.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_transform.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_game.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_game.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_matchmaking_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_matchmaking_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/text_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tile_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tile_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tiled.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tiled.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tmx_reader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tmx_reader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tileset_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tileset_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tooltip.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tooltip.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tree_view_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tree_view_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_object_compiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_object_compiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_render_level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_render_level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/video_selections.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/video_selections.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/weather_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/weather_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget_factory.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget_factory.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_properties.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_properties.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_selector.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_selector.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_styles.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_styles.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_stylesheet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_stylesheet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_transition.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_transition.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/event_listener.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/event_listener.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/scrollable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/scrollable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/solid_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/solid_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_absolute_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_absolute_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_background_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_background_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_border_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_border_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_element_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_element_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_layout_engine.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_layout_engine.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_line_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_line_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_listitem_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_listitem_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_render_ctx.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_render_ctx.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_root_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_root_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_script_interface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_script_interface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_style_tree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_style_tree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xslider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xslider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )

--- a/buildsystem/cmake-includes/silence-warnings/01-default/clang/04-enum-constexpr-conversion/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/01-default/clang/04-enum-constexpr-conversion/CMakeLists.txt
@@ -2,13 +2,13 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-enum-constexpr-conversion"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-enum-constexpr-conversion"
 )

--- a/buildsystem/cmake-includes/silence-warnings/01-default/clang/05-nontrivial-memcall/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/01-default/clang/05-nontrivial-memcall/CMakeLists.txt
@@ -2,61 +2,61 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/imgui/imgui.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/build/src/imgui/imgui.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nontrivial-memcall"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/imgui/imgui_draw.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/build/src/imgui/imgui_draw.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nontrivial-memcall"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/imgui/imgui_tables.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/build/src/imgui/imgui_tables.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nontrivial-memcall"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/imgui/imgui_widgets.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/build/src/imgui/imgui_widgets.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nontrivial-memcall"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/imgui_additions/imgui_custom.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/imgui_additions/imgui_custom.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nontrivial-memcall"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/input.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/input.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nontrivial-memcall"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemUI.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemUI.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nontrivial-memcall"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/WindowManager.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/WindowManager.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nontrivial-memcall"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/imgui_impl_sdl_gl3.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/imgui_impl_sdl_gl3.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nontrivial-memcall"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/theme_imgui.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/theme_imgui.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nontrivial-memcall"
 )

--- a/buildsystem/cmake-includes/silence-warnings/01-default/gcc/01-narrowing/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/01-default/gcc/01-narrowing/CMakeLists.txt
@@ -2,31 +2,31 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/cairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/cairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-narrowing"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-narrowing"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSDL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSDL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-narrowing"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceSDL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceSDL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-narrowing"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/md5.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/md5.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-narrowing"
 )

--- a/buildsystem/cmake-includes/silence-warnings/01-default/gcc/02-unused-result/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/01-default/gcc/02-unused-result/CMakeLists.txt
@@ -2,7 +2,7 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/cairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/cairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-result"
 )

--- a/buildsystem/cmake-includes/silence-warnings/01-default/gcc/03-aggressive-loop-optimizations/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/01-default/gcc/03-aggressive-loop-optimizations/CMakeLists.txt
@@ -2,7 +2,7 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-aggressive-loop-optimizations"
 )

--- a/buildsystem/cmake-includes/silence-warnings/01-default/gcc/04-deprecated-declarations/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/01-default/gcc/04-deprecated-declarations/CMakeLists.txt
@@ -2,7 +2,7 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations"
 )

--- a/buildsystem/cmake-includes/silence-warnings/02-lto/gcc/03-lto-type-mismatch/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/02-lto/gcc/03-lto-type-mismatch/CMakeLists.txt
@@ -2,4 +2,5 @@
 # XXX - We have to set this globally as otherwise it does not reach the linker!
 
 # XXX - Some of the type mismatches only pop up during LTO
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-lto-type-mismatch")
+# XXX - Needs to be globally exluded from errors due to how exactly it only bubbles up during LTO
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=stringop-overflow")

--- a/buildsystem/cmake-includes/silence-warnings/02-lto/gcc/04-stringpop-overflow/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/02-lto/gcc/04-stringpop-overflow/CMakeLists.txt
@@ -1,0 +1,5 @@
+# In an optimal state, this file does not exist
+# XXX - The leading spaces in this file are meaningful for string concatenation!
+
+# XXX - Some of the stringpop overflows only pop up during LTO
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-stringpop-overflow")

--- a/buildsystem/cmake-includes/silence-warnings/02-lto/gcc/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/02-lto/gcc/CMakeLists.txt
@@ -3,3 +3,4 @@
 include("${CMAKE_CURRENT_LIST_DIR}/01-odr/CMakeLists.txt")
 include("${CMAKE_CURRENT_LIST_DIR}/02-aggressive-loop-optimizations/CMakeLists.txt")
 include("${CMAKE_CURRENT_LIST_DIR}/03-lto-type-mismatch/CMakeLists.txt")
+include("${CMAKE_CURRENT_LIST_DIR}/04-stringpop-overflow/CMakeLists.txt")

--- a/buildsystem/cmake-includes/silence-warnings/03-all/clang/01-unneeded-internal-declaration/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/03-all/clang/01-unneeded-internal-declaration/CMakeLists.txt
@@ -2,1261 +2,1261 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/LayerBlitInfo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/LayerBlitInfo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ParticleSystemWidget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ParticleSystemWidget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/TextureObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/TextureObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_creator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_creator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_preview_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_preview_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/anura_shader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/anura_shader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/asserts.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/asserts.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/auto_update_window.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/auto_update_window.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/background.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/background.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/bar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/bar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/blur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/blur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/border_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/border_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/cairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/cairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/character_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/character_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/checkbox.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/checkbox.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/collision_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/collision_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/color_picker.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/color_picker.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/controls_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/controls_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/debug_console.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/debug_console.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/distortion.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/distortion.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/drag_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/drag_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_primitive.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_primitive.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_scene.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_scene.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dropdown_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dropdown_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_dialogs.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_dialogs.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_formula_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_formula_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_layers_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_layers_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_level_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_level_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_module_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_module_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_stats_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_stats_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/entity.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/entity.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/external_text_editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/external_text_editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_dom.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_dom.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/file_chooser_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/file_chooser_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_constants.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_constants.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_profiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_profiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_visualize_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_visualize_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/frame.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/framed_gui_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/framed_gui_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/geometry_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/geometry_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/grid_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/grid_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/group_property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/group_property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/gui_section.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/gui_section.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_helper.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_helper.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_loader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_loader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_mask.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_mask.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/tile_rules.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/tile_rules.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/image_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/image_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/input.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/input.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/json_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/json_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/key_button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/key_button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/AttributeSet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/AttributeSet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blend.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Blend.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blittable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Blittable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CameraObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CameraObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Canvas.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Canvas.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CanvasOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CanvasOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ClipScope.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ClipScope.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ClipScopeOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ClipScopeOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Cursor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Cursor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDevice.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDevice.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDeviceOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDeviceOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/EffectsOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/EffectsOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FboOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FboOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontDriver.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontDriver.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontFreetype.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontFreetype.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSDL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSDL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSTB.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSTB.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Gradients.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Gradients.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/LightObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/LightObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystem.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystem.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemAffectors.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemAffectors.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemEmitters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemEmitters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemUI.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemUI.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderQueue.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/RenderQueue.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderTarget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/RenderTarget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneGraph.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneGraph.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneNode.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneNode.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneTree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneTree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Scissor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Scissor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ScissorOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ScissorOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Shaders.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Shaders.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ShadersOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ShadersOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/StencilScope.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/StencilScope.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Surface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Surface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceBlur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceBlur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceSDL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceSDL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceScale.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceScale.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/TexPack.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/TexPack.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Texture.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Texture.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/TextureOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/TextureOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/UniformBufferOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/UniformBufferOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraph.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraph.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraphCairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraphCairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/WindowManager.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/WindowManager.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/language_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/language_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/layout_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/layout_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_logic.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_logic.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_runner.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_runner.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/light.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/light.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/load_level_nothread.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/load_level_nothread.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/loading_screen.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/loading_screen.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/message_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/message_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multi_tile_pattern.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multi_tile_pattern.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system_proxy.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system_proxy.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pathfinding.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pathfinding.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pause_game_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pause_game_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/playable_custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/playable_custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/player_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/player_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_line_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_line_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preferences.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preferences.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preview_tileset_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preview_tileset_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/progress_bar.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/progress_bar.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rect_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rect_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rectangle_rotator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rectangle_rotator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rich_text_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rich_text_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/screen_handling.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/screen_handling.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollable_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollable_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollbar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollbar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/segment_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/segment_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/settings_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/settings_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/slider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/slider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/solid_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/solid_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sound.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/speech_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/speech_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_cache.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_cache.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_palette.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_palette.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/easy_svg.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/easy_svg.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_container.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_container.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_gradient.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_gradient.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_paint.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_paint.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_parse.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_parse.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_shapes.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_shapes.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_style.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_style.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_transform.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_transform.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/text_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tile_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tile_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tiled.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tiled.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tmx_reader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tmx_reader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tileset_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tileset_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tooltip.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tooltip.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tree_view_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tree_view_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_object_compiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_object_compiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_render_level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_render_level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/video_selections.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/video_selections.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/weather_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/weather_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget_factory.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget_factory.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_properties.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_properties.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_selector.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_selector.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_styles.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_styles.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_stylesheet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_stylesheet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_transition.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_transition.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/event_listener.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/event_listener.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/scrollable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/scrollable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/solid_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/solid_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_absolute_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_absolute_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_background_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_background_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_border_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_border_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_element_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_element_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_layout_engine.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_layout_engine.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_line_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_line_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_listitem_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_listitem_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_render_ctx.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_render_ctx.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_root_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_root_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_script_interface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_script_interface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_style_tree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_style_tree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xslider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xslider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unneeded-internal-declaration"
 )

--- a/buildsystem/cmake-includes/silence-warnings/03-all/clang/02-reorder-ctor/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/03-all/clang/02-reorder-ctor/CMakeLists.txt
@@ -2,1202 +2,1202 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ColorTransform.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ColorTransform.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ParticleSystemWidget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ParticleSystemWidget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/SceneObjectCallable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/SceneObjectCallable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/TextureObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/TextureObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/achievements.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/achievements.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_creator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_creator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_preview_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_preview_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/anura_shader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/anura_shader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/asserts.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/asserts.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/auto_update_window.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/auto_update_window.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/background.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/background.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/bar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/bar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/blur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/blur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/border_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/border_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/cairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/cairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/character_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/character_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/checkbox.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/checkbox.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/checksum.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/checksum.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/collision_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/collision_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/color_picker.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/color_picker.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/compress.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/compress.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/controls.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/controls.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/controls_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/controls_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/current_generator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/current_generator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/db_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/db_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/debug_console.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/debug_console.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/difficulty.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/difficulty.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/distortion.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/distortion.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/drag_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/drag_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_primitive.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_primitive.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_scene.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_scene.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dropdown_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dropdown_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_dialogs.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_dialogs.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_formula_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_formula_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_layers_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_layers_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_level_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_level_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_module_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_module_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_stats_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_stats_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_variable_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_variable_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/entity.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/entity.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/external_text_editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/external_text_editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_dom.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_dom.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_lib.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_lib.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/file_chooser_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/file_chooser_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_callable_definition.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_callable_definition.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_callable_visitor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_callable_visitor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_constants.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_constants.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function_registry.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function_registry.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_garbage_collector.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_garbage_collector.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_interface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_interface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_internal.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_internal.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_profiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_profiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_test.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_test.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_variable_storage.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_variable_storage.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_visualize_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_visualize_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_vm.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_vm.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/frame.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/framed_gui_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/framed_gui_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ft_iface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ft_iface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/game_registry.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/game_registry.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/geometry_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/geometry_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/grid_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/grid_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/group_property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/group_property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_loader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_loader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_mask.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_mask.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/tile_rules.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/tile_rules.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/http_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/http_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/http_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/http_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/i18n.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/i18n.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/image_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/image_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/joystick.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/joystick.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/json_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/json_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/key_button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/key_button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/AttributeSet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/AttributeSet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blittable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Blittable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CameraObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CameraObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDeviceOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDeviceOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/EffectsOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/EffectsOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSTB.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSTB.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/LightObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/LightObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystem.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystem.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemAffectors.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemAffectors.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemEmitters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemEmitters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemParameters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemParameters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemUI.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemUI.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderTarget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/RenderTarget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneNode.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneNode.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneTree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneTree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ShadersOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ShadersOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/WindowManager.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/WindowManager.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/language_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/language_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/layout_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/layout_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_logic.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_logic.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_runner.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_runner.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/light.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/light.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/load_level_nothread.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/load_level_nothread.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/loading_screen.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/loading_screen.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multi_tile_pattern.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multi_tile_pattern.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/object_events.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/object_events.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system_proxy.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system_proxy.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pathfinding.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pathfinding.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pause_game_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pause_game_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/playable_custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/playable_custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/player_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/player_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_line_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_line_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preferences.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preferences.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preprocessor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preprocessor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preview_tileset_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preview_tileset_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/progress_bar.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/progress_bar.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rich_text_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rich_text_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollable_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollable_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollbar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollbar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/segment_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/segment_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/shared_memory_pipe.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/shared_memory_pipe.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/slider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/slider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sound.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/speech_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/speech_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_cache.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_cache.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_palette.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_palette.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_container.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_container.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_paint.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_paint.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_parse.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_parse.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_path_parse.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_path_parse.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_shapes.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_shapes.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_style.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_style.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_ai_player.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_ai_player.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_bot.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_bot.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_game.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_game.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_internal_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_internal_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_ipc_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_ipc_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_matchmaking_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_matchmaking_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_relay_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_relay_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server_base.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server_base.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/text_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/theme_imgui.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/theme_imgui.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tile_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tile_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tmx_reader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tmx_reader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tileset_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tileset_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tooltip.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tooltip.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tree_view_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tree_view_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_object_compiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_object_compiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_query.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_query.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_render_level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_render_level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/video_selections.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/video_selections.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/weather_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/weather_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget_factory.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget_factory.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/wml_formula_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/wml_formula_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_lexer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_lexer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xslider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xslider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder-ctor -Wno-reorder"
 )

--- a/buildsystem/cmake-includes/silence-warnings/03-all/clang/03-unused-private-field/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/03-all/clang/03-unused-private-field/CMakeLists.txt
@@ -2,883 +2,883 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/LayerBlitInfo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/LayerBlitInfo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ParticleSystemWidget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ParticleSystemWidget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_creator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_creator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_preview_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_preview_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/anura_shader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/anura_shader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/asserts.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/asserts.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/background.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/background.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/blur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/blur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/cairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/cairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/character_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/character_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/collision_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/collision_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/debug_console.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/debug_console.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_primitive.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_primitive.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_scene.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_scene.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_formula_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_formula_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_layers_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_layers_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_level_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_level_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_module_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_module_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_stats_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_stats_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/entity.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/entity.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/external_text_editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/external_text_editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_dom.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_dom.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_profiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_profiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_visualize_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_visualize_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_vm.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_vm.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/frame.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ft_iface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ft_iface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/group_property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/group_property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_mask.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_mask.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/http_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/http_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/joystick.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/joystick.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/json_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/json_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/AttributeSet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/AttributeSet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/AttributeSet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/AttributeSet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/AttributeSetOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/AttributeSetOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blittable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Blittable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Canvas.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Canvas.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ClipScopeOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ClipScopeOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Depth.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Depth.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDevice.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDevice.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDeviceOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDeviceOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FboOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FboOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontDriver.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontDriver.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontFreetype.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontFreetype.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSTB.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSTB.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Gradients.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Gradients.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystem.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystem.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemAffectors.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemAffectors.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemEmitters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemEmitters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemUI.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemUI.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderTarget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/RenderTarget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneNode.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneNode.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneTree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneTree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ShadersOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ShadersOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraph.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraph.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraphCairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraphCairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_logic.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_logic.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_runner.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_runner.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/light.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/light.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/load_level_nothread.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/load_level_nothread.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/loading_screen.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/loading_screen.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system_proxy.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system_proxy.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pathfinding.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pathfinding.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pause_game_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pause_game_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/playable_custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/playable_custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/player_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/player_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preferences.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preferences.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rect_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rect_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollbar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollbar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/segment_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/segment_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sound.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/speech_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/speech_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/easy_svg.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/easy_svg.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_container.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_container.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_gradient.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_gradient.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_paint.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_paint.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_parse.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_parse.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_shapes.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_shapes.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_style.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_style.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_transform.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_transform.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_game.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_game.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_matchmaking_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_matchmaking_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/text_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tile_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tile_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tiled.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tiled.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tmx_reader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tmx_reader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tileset_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tileset_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_object_compiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_object_compiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_render_level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_render_level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/video_selections.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/video_selections.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/weather_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/weather_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget_factory.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget_factory.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_lexer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_lexer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_selector.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_selector.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_styles.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_styles.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_stylesheet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_stylesheet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/scrollable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/scrollable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/solid_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/solid_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_absolute_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_absolute_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_background_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_background_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_border_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_border_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_element_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_element_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_layout_engine.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_layout_engine.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_line_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_line_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_listitem_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_listitem_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_render_ctx.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_render_ctx.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_root_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_root_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_script_interface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_script_interface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_style_tree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_style_tree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xslider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xslider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-private-field"
 )

--- a/buildsystem/cmake-includes/silence-warnings/03-all/clang/04-unused-function/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/03-all/clang/04-unused-function/CMakeLists.txt
@@ -2,565 +2,565 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_preview_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_preview_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/anura_shader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/anura_shader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/asserts.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/asserts.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/auto_update_window.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/auto_update_window.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/background.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/background.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/bar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/bar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/border_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/border_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/character_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/character_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/collision_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/collision_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/color_picker.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/color_picker.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/debug_console.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/debug_console.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_primitive.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_primitive.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_scene.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_scene.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dropdown_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dropdown_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_formula_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_formula_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_layers_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_layers_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_level_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_level_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_module_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_module_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_stats_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_stats_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/entity.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/entity.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_dom.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_dom.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_profiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_profiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_visualize_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_visualize_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/frame.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/framed_gui_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/framed_gui_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/grid_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/grid_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/group_property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/group_property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/gui_section.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/gui_section.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/tile_rules.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/tile_rules.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/http_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/http_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/image_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/image_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/key_button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/key_button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Canvas.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Canvas.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CanvasOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CanvasOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDevice.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDevice.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDeviceOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDeviceOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSTB.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSTB.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystem.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystem.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraph.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraph.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraphCairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraphCairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_logic.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_logic.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_runner.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_runner.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/load_level_nothread.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/load_level_nothread.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/loading_screen.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/loading_screen.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/message_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/message_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multi_tile_pattern.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multi_tile_pattern.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pathfinding.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pathfinding.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/playable_custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/playable_custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_line_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_line_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preferences.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preferences.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preview_tileset_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preview_tileset_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/progress_bar.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/progress_bar.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rich_text_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rich_text_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/segment_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/segment_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/slider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/slider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/speech_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/speech_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_paint.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_paint.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_parse.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_parse.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_path_parse.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_path_parse.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_game.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_game.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/text_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tile_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tile_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tileset_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tileset_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tooltip.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tooltip.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tree_view_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tree_view_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_render_level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_render_level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/video_selections.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/video_selections.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget_factory.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget_factory.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_background_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_background_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )

--- a/buildsystem/cmake-includes/silence-warnings/03-all/clang/05-unused-variable/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/03-all/clang/05-unused-variable/CMakeLists.txt
@@ -2,560 +2,560 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ParticleSystemWidget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ParticleSystemWidget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/VoronoiDiagramGenerator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/VoronoiDiagramGenerator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/anura_shader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/anura_shader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/auto_update_window.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/auto_update_window.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/background.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/background.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/bar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/bar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/cairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/cairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/character_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/character_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/collision_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/collision_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/compress.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/compress.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/controls_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/controls_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/debug_console.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/debug_console.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_primitive.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_primitive.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dropdown_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dropdown_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_lib.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_lib.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_profiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_profiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_tokenizer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_tokenizer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_vm.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_vm.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/frame.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/grid_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/grid_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/tile_rules.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/tile_rules.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/image_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/image_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/joystick.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/joystick.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontFreetype.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontFreetype.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSTB.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSTB.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemAffectors.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemAffectors.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemUI.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemUI.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceScale.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceScale.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/WindowManager.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/WindowManager.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/language_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/language_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/layout_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/layout_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_runner.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_runner.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/light.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/light.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/loading_screen.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/loading_screen.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system_proxy.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system_proxy.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preferences.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preferences.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preview_tileset_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preview_tileset_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rich_text_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rich_text_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/screen_handling.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/screen_handling.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollbar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollbar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/settings_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/settings_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/simplex_noise_tests.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/simplex_noise_tests.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/slider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/slider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sound.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/speech_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/speech_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_length.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_length.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_bot.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_bot.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_game.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_game.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_internal_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_matchmaking_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_matchmaking_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server_base.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server_base.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/text_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tile_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tile_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tileset_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tileset_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tree_view_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tree_view_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_object_compiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_object_compiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_properties.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_properties.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_transition.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_transition.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/scrollable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/scrollable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_absolute_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_absolute_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_background_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_background_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_border_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_border_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_element_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_element_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_layout_engine.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_layout_engine.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_render_ctx.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_render_ctx.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )

--- a/buildsystem/cmake-includes/silence-warnings/03-all/clang/06-overloaded-virtual/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/03-all/clang/06-overloaded-virtual/CMakeLists.txt
@@ -2,505 +2,505 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/anura_shader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/anura_shader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/asserts.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/asserts.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/background.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/background.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/blur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/blur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/character_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/character_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/collision_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/collision_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/debug_console.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/debug_console.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_primitive.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_primitive.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_scene.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_scene.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_formula_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_formula_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_layers_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_layers_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_level_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_level_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_module_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_module_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_stats_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_stats_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/entity.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/entity.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_dom.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_dom.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_profiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_profiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/frame.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/group_property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/group_property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/json_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/json_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_logic.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_logic.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_runner.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_runner.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/light.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/light.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/load_level_nothread.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/load_level_nothread.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pathfinding.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pathfinding.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pause_game_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pause_game_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/playable_custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/playable_custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preferences.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preferences.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollbar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollbar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/segment_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/segment_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sound.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_ai_player.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_ai_player.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_game.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_game.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_internal_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_internal_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_matchmaking_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_matchmaking_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_relay_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_relay_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server_base.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server_base.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/text_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tileset_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tileset_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_render_level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_render_level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/video_selections.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/video_selections.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget_factory.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget_factory.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_selector.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_selector.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_stylesheet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_stylesheet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/solid_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/solid_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_absolute_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_absolute_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_background_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_background_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_border_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_border_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_element_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_element_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_layout_engine.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_layout_engine.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_line_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_line_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_listitem_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_listitem_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_root_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_root_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_script_interface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_script_interface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_style_tree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_style_tree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )

--- a/buildsystem/cmake-includes/silence-warnings/03-all/clang/07-unused-but-set-variable/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/03-all/clang/07-unused-but-set-variable/CMakeLists.txt
@@ -2,91 +2,91 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/auto_update_window.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/auto_update_window.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_garbage_collector.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_garbage_collector.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontFreetype.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontFreetype.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/TextureOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/TextureOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/WindowManager.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/WindowManager.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_matchmaking_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_matchmaking_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tile_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tile_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_object_compiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_object_compiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )

--- a/buildsystem/cmake-includes/silence-warnings/03-all/clang/08-unused-local-typedef/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/03-all/clang/08-unused-local-typedef/CMakeLists.txt
@@ -2,43 +2,43 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/blur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/blur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-local-typedef"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/character_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/character_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-local-typedef"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-local-typedef"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/external_text_editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/external_text_editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-local-typedef"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/frame.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-local-typedef"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sound.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-local-typedef"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_object_compiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_object_compiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-local-typedef"
 )

--- a/buildsystem/cmake-includes/silence-warnings/03-all/clang/09-unused-const-variable/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/03-all/clang/09-unused-const-variable/CMakeLists.txt
@@ -2,19 +2,19 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Frustum.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Frustum.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-const-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneNode.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneNode.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-const-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-const-variable"
 )

--- a/buildsystem/cmake-includes/silence-warnings/03-all/clang/10-unused-lambda-capture/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/03-all/clang/10-unused-lambda-capture/CMakeLists.txt
@@ -2,7 +2,7 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/video_selections.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/video_selections.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-lambda-capture"
 )

--- a/buildsystem/cmake-includes/silence-warnings/03-all/gcc/01-sign-compare/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/03-all/gcc/01-sign-compare/CMakeLists.txt
@@ -2,1584 +2,1584 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ColorTransform.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ColorTransform.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/LayerBlitInfo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/LayerBlitInfo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ParticleSystemWidget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ParticleSystemWidget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/SceneObjectCallable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/SceneObjectCallable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/TextureObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/TextureObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_creator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_creator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_preview_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_preview_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/anura_shader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/anura_shader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/asserts.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/asserts.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/auto_update_window.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/auto_update_window.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/background.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/background.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/bar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/bar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/blur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/blur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/border_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/border_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/cairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/cairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/character_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/character_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/checkbox.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/checkbox.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/checksum.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/checksum.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/collision_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/collision_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/color_picker.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/color_picker.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/compress.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/compress.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/controls.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/controls.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/controls_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/controls_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/current_generator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/current_generator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/db_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/db_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/debug_console.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/debug_console.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/distortion.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/distortion.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/drag_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/drag_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_primitive.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_primitive.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_scene.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_scene.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dropdown_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dropdown_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_dialogs.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_dialogs.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_formula_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_formula_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_layers_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_layers_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_level_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_level_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_module_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_module_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_stats_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_stats_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_variable_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_variable_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/entity.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/entity.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/external_text_editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/external_text_editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_dom.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_dom.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_lib.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_lib.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/file_chooser_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/file_chooser_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/filesystem.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/filesystem.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_callable_definition.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_callable_definition.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_constants.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_constants.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function_registry.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function_registry.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_garbage_collector.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_garbage_collector.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_interface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_interface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_internal.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_internal.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_profiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_profiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_test.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_test.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_tokenizer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_tokenizer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_visualize_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_visualize_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_vm.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_vm.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/frame.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/framed_gui_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/framed_gui_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/game_registry.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/game_registry.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/geometry_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/geometry_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/grid_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/grid_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/group_property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/group_property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/gui_section.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/gui_section.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_helper.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_helper.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_loader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_loader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_mask.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_mask.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/tile_rules.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/tile_rules.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/http_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/http_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/http_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/http_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/image_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/image_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/input.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/input.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/joystick.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/joystick.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/json_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/json_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/key_button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/key_button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/AttributeSet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/AttributeSet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blend.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Blend.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blittable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Blittable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CameraObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CameraObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Canvas.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Canvas.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CanvasOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CanvasOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ClipScope.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ClipScope.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ClipScopeOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ClipScopeOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Color.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Color.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Cursor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Cursor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDevice.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDevice.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDeviceOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDeviceOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/EffectsOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/EffectsOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FboOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FboOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontDriver.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontDriver.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontFreetype.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontFreetype.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSDL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSDL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSTB.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSTB.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Gradients.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Gradients.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/LightObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/LightObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystem.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystem.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemAffectors.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemAffectors.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemEmitters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemEmitters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemParameters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemParameters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemUI.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemUI.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderQueue.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/RenderQueue.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderTarget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/RenderTarget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneGraph.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneGraph.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneNode.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneNode.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneTree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneTree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Scissor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Scissor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ScissorOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ScissorOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Shaders.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Shaders.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ShadersOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ShadersOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/StencilScope.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/StencilScope.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Surface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Surface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceBlur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceBlur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceSDL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceSDL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceScale.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceScale.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/TexPack.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/TexPack.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Texture.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Texture.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/TextureOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/TextureOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/UniformBufferOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/UniformBufferOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraph.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraph.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraphCairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraphCairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/WindowManager.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/WindowManager.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/language_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/language_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/layout_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/layout_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_logic.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_logic.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_runner.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_runner.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_solid_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_solid_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/light.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/light.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/load_level_nothread.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/load_level_nothread.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/loading_screen.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/loading_screen.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/message_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/message_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multi_tile_pattern.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multi_tile_pattern.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/object_events.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/object_events.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system_proxy.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system_proxy.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pathfinding.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pathfinding.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pause_game_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pause_game_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/playable_custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/playable_custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/player_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/player_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_line_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_line_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preferences.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preferences.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preprocessor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preprocessor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preview_tileset_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preview_tileset_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/progress_bar.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/progress_bar.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rect_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rect_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rectangle_rotator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rectangle_rotator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rich_text_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rich_text_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/screen_handling.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/screen_handling.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollable_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollable_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollbar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollbar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/segment_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/segment_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/settings_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/settings_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/slider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/slider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/solid_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/solid_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sound.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/speech_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/speech_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/string_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/string_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_cache.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_cache.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_palette.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_palette.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/easy_svg.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/easy_svg.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_container.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_container.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_gradient.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_gradient.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_paint.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_paint.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_parse.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_parse.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_shapes.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_shapes.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_style.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_style.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_transform.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_transform.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_ai_player.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_ai_player.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_bot.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_bot.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_game.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_game.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_internal_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_internal_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_ipc_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_ipc_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_matchmaking_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_matchmaking_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_relay_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_relay_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server_base.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server_base.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/text_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tile_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tile_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tiled.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tiled.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tmx_reader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tmx_reader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tileset_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tileset_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tooltip.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tooltip.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tree_view_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tree_view_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_object_compiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_object_compiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_query.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_query.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_render_level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_render_level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/video_selections.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/video_selections.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/weather_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/weather_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget_factory.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget_factory.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/wml_formula_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/wml_formula_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_lexer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_lexer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_properties.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_properties.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_selector.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_selector.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_styles.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_styles.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_stylesheet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_stylesheet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_transition.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_transition.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/event_listener.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/event_listener.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/scrollable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/scrollable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/solid_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/solid_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_absolute_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_absolute_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_background_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_background_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_border_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_border_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_element_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_element_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_layout_engine.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_layout_engine.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_line_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_line_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_listitem_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_listitem_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_render_ctx.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_render_ctx.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_root_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_root_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_script_interface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_script_interface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_style_tree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_style_tree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xslider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xslider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )

--- a/buildsystem/cmake-includes/silence-warnings/03-all/gcc/02-reorder/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/03-all/gcc/02-reorder/CMakeLists.txt
@@ -2,1201 +2,1201 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ColorTransform.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ColorTransform.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ParticleSystemWidget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ParticleSystemWidget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/SceneObjectCallable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/SceneObjectCallable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/TextureObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/TextureObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/achievements.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/achievements.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_creator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_creator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_preview_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_preview_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/anura_shader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/anura_shader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/asserts.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/asserts.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/auto_update_window.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/auto_update_window.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/background.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/background.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/bar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/bar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/blur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/blur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/border_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/border_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/cairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/cairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/character_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/character_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/checkbox.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/checkbox.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/checksum.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/checksum.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/collision_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/collision_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/color_picker.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/color_picker.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/compress.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/compress.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/controls.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/controls.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/controls_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/controls_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/current_generator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/current_generator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/db_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/db_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/debug_console.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/debug_console.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/difficulty.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/difficulty.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/distortion.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/distortion.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/drag_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/drag_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_primitive.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_primitive.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_scene.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_scene.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dropdown_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dropdown_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_dialogs.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_dialogs.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_formula_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_formula_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_layers_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_layers_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_level_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_level_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_module_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_module_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_stats_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_stats_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_variable_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_variable_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/entity.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/entity.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/external_text_editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/external_text_editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_dom.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_dom.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_lib.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_lib.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/file_chooser_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/file_chooser_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_callable_definition.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_callable_definition.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_callable_visitor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_callable_visitor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_constants.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_constants.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function_registry.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function_registry.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_garbage_collector.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_garbage_collector.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_interface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_interface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_internal.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_internal.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_profiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_profiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_test.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_test.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_variable_storage.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_variable_storage.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_visualize_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_visualize_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_vm.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_vm.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/frame.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/framed_gui_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/framed_gui_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ft_iface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ft_iface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/game_registry.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/game_registry.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/geometry_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/geometry_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/grid_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/grid_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/group_property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/group_property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_loader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_loader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_mask.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_mask.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/tile_rules.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/tile_rules.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/http_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/http_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/http_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/http_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/i18n.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/i18n.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/image_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/image_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/joystick.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/joystick.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/json_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/json_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/key_button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/key_button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/AttributeSet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/AttributeSet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blittable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Blittable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CameraObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CameraObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDeviceOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDeviceOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/EffectsOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/EffectsOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSTB.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSTB.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/LightObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/LightObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystem.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystem.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemAffectors.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemAffectors.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemEmitters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemEmitters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemParameters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemParameters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemUI.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemUI.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderTarget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/RenderTarget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneNode.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneNode.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneTree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneTree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ShadersOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ShadersOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/WindowManager.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/WindowManager.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/language_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/language_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/layout_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/layout_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_logic.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_logic.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_runner.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_runner.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/light.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/light.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/load_level_nothread.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/load_level_nothread.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/loading_screen.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/loading_screen.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multi_tile_pattern.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multi_tile_pattern.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/object_events.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/object_events.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system_proxy.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system_proxy.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pathfinding.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pathfinding.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pause_game_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pause_game_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/playable_custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/playable_custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/player_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/player_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_line_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_line_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preferences.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preferences.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preprocessor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preprocessor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preview_tileset_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preview_tileset_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/progress_bar.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/progress_bar.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rich_text_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rich_text_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollable_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollable_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollbar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollbar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/segment_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/segment_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/shared_memory_pipe.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/shared_memory_pipe.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/slider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/slider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sound.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/speech_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/speech_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_cache.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_cache.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_palette.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_palette.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_container.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_container.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_paint.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_paint.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_parse.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_parse.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_path_parse.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_path_parse.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_shapes.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_shapes.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_style.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_style.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_ai_player.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_ai_player.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_bot.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_bot.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_game.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_game.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_internal_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_internal_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_ipc_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_ipc_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_matchmaking_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_matchmaking_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_relay_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_relay_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server_base.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server_base.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/text_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/theme_imgui.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/theme_imgui.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tile_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tile_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tmx_reader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tmx_reader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tileset_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tileset_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tooltip.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tooltip.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tree_view_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tree_view_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_object_compiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_object_compiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_query.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_query.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_render_level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_render_level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/video_selections.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/video_selections.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/weather_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/weather_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget_factory.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget_factory.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/wml_formula_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/wml_formula_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_lexer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_lexer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xslider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xslider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-reorder"
 )

--- a/buildsystem/cmake-includes/silence-warnings/03-all/gcc/03-unused-function/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/03-all/gcc/03-unused-function/CMakeLists.txt
@@ -2,571 +2,571 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_preview_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_preview_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/anura_shader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/anura_shader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/asserts.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/asserts.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/auto_update_window.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/auto_update_window.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/background.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/background.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/bar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/bar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/border_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/border_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/character_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/character_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/collision_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/collision_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/color_picker.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/color_picker.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/debug_console.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/debug_console.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_primitive.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_primitive.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_scene.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_scene.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dropdown_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dropdown_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_formula_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_formula_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_layers_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_layers_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_level_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_level_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_module_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_module_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_stats_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_stats_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/entity.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/entity.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_dom.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_dom.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_profiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_profiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_visualize_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_visualize_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/frame.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/framed_gui_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/framed_gui_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/grid_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/grid_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/group_property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/group_property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/gui_section.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/gui_section.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/tile_rules.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/tile_rules.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/http_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/http_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/image_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/image_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/key_button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/key_button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Canvas.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Canvas.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CanvasOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CanvasOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDevice.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDevice.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDeviceOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDeviceOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSTB.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSTB.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystem.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystem.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraph.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraph.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraphCairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraphCairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_logic.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_logic.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_runner.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_runner.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/load_level_nothread.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/load_level_nothread.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/loading_screen.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/loading_screen.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/message_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/message_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multi_tile_pattern.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multi_tile_pattern.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pathfinding.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pathfinding.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/playable_custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/playable_custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_line_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_line_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preferences.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preferences.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preview_tileset_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preview_tileset_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/progress_bar.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/progress_bar.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rich_text_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rich_text_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/segment_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/segment_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/slider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/slider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sound.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/speech_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/speech_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_paint.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_paint.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_parse.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_parse.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_path_parse.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_path_parse.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_game.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_game.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/text_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tile_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tile_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tileset_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tileset_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tooltip.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tooltip.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tree_view_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tree_view_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_render_level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_render_level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/video_selections.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/video_selections.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget_factory.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget_factory.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_background_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_background_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-function"
 )

--- a/buildsystem/cmake-includes/silence-warnings/03-all/gcc/04-unused-variable/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/03-all/gcc/04-unused-variable/CMakeLists.txt
@@ -2,547 +2,547 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ParticleSystemWidget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ParticleSystemWidget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/VoronoiDiagramGenerator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/VoronoiDiagramGenerator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/anura_shader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/anura_shader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/auto_update_window.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/auto_update_window.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/background.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/background.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/bar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/bar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/cairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/cairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/character_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/character_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/collision_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/collision_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/compress.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/compress.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/controls_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/controls_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/debug_console.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/debug_console.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_primitive.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_primitive.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dropdown_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dropdown_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_lib.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_lib.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_profiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_profiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_vm.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_vm.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/frame.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/grid_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/grid_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/tile_rules.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/tile_rules.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/image_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/image_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/joystick.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/joystick.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/joystick.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/joystick.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontFreetype.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontFreetype.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSTB.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSTB.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemAffectors.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemAffectors.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemUI.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemUI.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceScale.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceScale.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/language_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/language_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/layout_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/layout_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_runner.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_runner.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/light.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/light.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/loading_screen.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/loading_screen.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system_proxy.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system_proxy.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preferences.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preferences.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preview_tileset_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preview_tileset_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rich_text_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rich_text_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/screen_handling.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/screen_handling.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollbar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollbar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/settings_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/settings_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/simplex_noise_tests.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/simplex_noise_tests.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/slider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/slider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sound.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/speech_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/speech_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_length.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_length.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_bot.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_bot.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_game.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_game.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_internal_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_matchmaking_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_matchmaking_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server_base.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server_base.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/text_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tile_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tile_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tileset_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tileset_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tree_view_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tree_view_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_object_compiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_object_compiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_properties.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_properties.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_transition.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_transition.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/scrollable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/scrollable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_absolute_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_absolute_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_background_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_background_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_border_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_border_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_element_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_element_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_layout_engine.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_layout_engine.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_render_ctx.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_render_ctx.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-variable"
 )

--- a/buildsystem/cmake-includes/silence-warnings/03-all/gcc/05-overloaded-virtual/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/03-all/gcc/05-overloaded-virtual/CMakeLists.txt
@@ -2,505 +2,505 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/anura_shader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/anura_shader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/asserts.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/asserts.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/background.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/background.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/blur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/blur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/character_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/character_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/collision_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/collision_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/debug_console.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/debug_console.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_primitive.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_primitive.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_scene.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_scene.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_formula_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_formula_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_layers_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_layers_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_level_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_level_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_module_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_module_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_stats_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_stats_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/entity.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/entity.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_dom.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_dom.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_profiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_profiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/frame.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/group_property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/group_property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/json_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/json_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_logic.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_logic.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_runner.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_runner.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/light.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/light.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/load_level_nothread.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/load_level_nothread.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pathfinding.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pathfinding.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pause_game_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pause_game_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/playable_custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/playable_custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preferences.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preferences.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollbar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollbar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/segment_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/segment_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sound.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_ai_player.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_ai_player.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_game.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_game.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_internal_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_internal_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_matchmaking_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_matchmaking_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_relay_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_relay_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server_base.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server_base.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/text_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tileset_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tileset_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_render_level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_render_level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/video_selections.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/video_selections.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget_factory.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget_factory.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_selector.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_selector.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_stylesheet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_stylesheet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/solid_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/solid_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_absolute_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_absolute_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_background_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_background_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_border_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_border_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_element_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_element_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_layout_engine.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_layout_engine.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_line_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_line_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_listitem_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_listitem_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_root_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_root_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_script_interface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_script_interface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_style_tree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_style_tree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-overloaded-virtual"
 )

--- a/buildsystem/cmake-includes/silence-warnings/03-all/gcc/06-unused-but-set-variable/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/03-all/gcc/06-unused-but-set-variable/CMakeLists.txt
@@ -2,73 +2,73 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_tokenizer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_tokenizer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/joystick.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/joystick.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontFreetype.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontFreetype.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemAffectors.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemAffectors.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/WindowManager.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/WindowManager.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_matchmaking_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_matchmaking_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-but-set-variable"
 )

--- a/buildsystem/cmake-includes/silence-warnings/03-all/gcc/07-unused-local-typedefs/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/03-all/gcc/07-unused-local-typedefs/CMakeLists.txt
@@ -2,43 +2,43 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/blur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/blur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-local-typedefs"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/character_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/character_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-local-typedefs"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-local-typedefs"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/external_text_editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/external_text_editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-local-typedefs"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/frame.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-local-typedefs"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sound.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-local-typedefs"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_object_compiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_object_compiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-local-typedefs"
 )

--- a/buildsystem/cmake-includes/silence-warnings/03-all/gcc/08-use-after-free/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/03-all/gcc/08-use-after-free/CMakeLists.txt
@@ -2,25 +2,25 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-use-after-free"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-use-after-free"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sound.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-use-after-free"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/text_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-use-after-free"
 )

--- a/buildsystem/cmake-includes/silence-warnings/03-all/gcc/09-maybe-uninitialized/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/03-all/gcc/09-maybe-uninitialized/CMakeLists.txt
@@ -2,7 +2,7 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/VoronoiDiagramGenerator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/VoronoiDiagramGenerator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-maybe-uninitialized"
 )

--- a/buildsystem/cmake-includes/silence-warnings/04-extra/clang/01-unused-parameter/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/04-extra/clang/01-unused-parameter/CMakeLists.txt
@@ -2,1759 +2,1759 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ColorTransform.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ColorTransform.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/LayerBlitInfo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/LayerBlitInfo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ParticleSystemWidget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ParticleSystemWidget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/SceneObjectCallable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/SceneObjectCallable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/TextureObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/TextureObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/VoronoiDiagramGenerator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/VoronoiDiagramGenerator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/achievements.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/achievements.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_creator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_creator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_preview_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_preview_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/anura_shader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/anura_shader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/asserts.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/asserts.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/auto_update_window.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/auto_update_window.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/background.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/background.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/bar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/bar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/blur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/blur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/border_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/border_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/cairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/cairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/character_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/character_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/checkbox.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/checkbox.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/checksum.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/checksum.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/clipboard.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/clipboard.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/collision_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/collision_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/color_picker.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/color_picker.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/compress.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/compress.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/controls.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/controls.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/controls_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/controls_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/current_generator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/current_generator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/db_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/db_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/debug_console.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/debug_console.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/difficulty.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/difficulty.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/distortion.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/distortion.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/drag_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/drag_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_primitive.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_primitive.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_scene.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_scene.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dropdown_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dropdown_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_dialogs.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_dialogs.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_formula_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_formula_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_layers_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_layers_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_level_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_level_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_module_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_module_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_stats_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_stats_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_variable_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_variable_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/entity.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/entity.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/external_text_editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/external_text_editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_dom.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_dom.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_lib.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_lib.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/file_chooser_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/file_chooser_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/filesystem.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/filesystem.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_callable_definition.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_callable_definition.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_callable_visitor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_callable_visitor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_constants.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_constants.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function_registry.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function_registry.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_garbage_collector.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_garbage_collector.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_interface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_interface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_internal.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_internal.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_profiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_profiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_test.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_test.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_variable_storage.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_variable_storage.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_visualize_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_visualize_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_vm.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_vm.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/frame.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/framed_gui_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/framed_gui_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ft_iface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ft_iface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/game_registry.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/game_registry.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/geometry_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/geometry_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/grid_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/grid_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/group_property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/group_property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/gui_section.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/gui_section.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_helper.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_helper.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_loader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_loader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_mask.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_mask.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/tile_rules.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/tile_rules.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/http_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/http_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/http_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/http_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/i18n.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/i18n.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/image_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/image_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/input.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/input.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/joystick.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/joystick.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/json_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/json_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/key_button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/key_button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/AttributeSet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/AttributeSet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/AttributeSetOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/AttributeSetOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blend.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Blend.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/BlendModeScope.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/BlendModeScope.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/BlendOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/BlendOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blittable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Blittable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CameraObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CameraObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Canvas.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Canvas.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CanvasOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CanvasOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ClipScope.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ClipScope.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ClipScopeOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ClipScopeOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Color.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Color.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ColorScope.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ColorScope.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Cursor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Cursor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Depth.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Depth.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDevice.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDevice.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDeviceOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDeviceOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/EffectsOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/EffectsOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FboOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FboOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontDriver.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontDriver.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontFreetype.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontFreetype.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSDL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSDL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSTB.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSTB.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Gradients.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Gradients.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/LightObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/LightObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystem.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystem.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemAffectors.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemAffectors.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemEmitters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemEmitters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemParameters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemParameters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemUI.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemUI.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderQueue.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/RenderQueue.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderTarget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/RenderTarget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneGraph.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneGraph.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneNode.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneNode.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneParameters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneParameters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneTree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneTree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Scissor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Scissor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ScissorOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ScissorOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Shaders.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Shaders.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ShadersOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ShadersOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/StencilScope.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/StencilScope.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Surface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Surface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceBlur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceBlur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceSDL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceSDL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceScale.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceScale.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/TexPack.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/TexPack.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Texture.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Texture.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/TextureOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/TextureOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/UniformBufferOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/UniformBufferOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraph.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraph.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraphCairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraphCairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/WindowManager.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/WindowManager.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/language_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/language_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/layout_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/layout_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_logic.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_logic.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_runner.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_runner.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_solid_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_solid_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/light.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/light.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/load_level_nothread.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/load_level_nothread.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/loading_screen.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/loading_screen.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/logger.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/logger.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/md5.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/md5.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/message_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/message_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multi_tile_pattern.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multi_tile_pattern.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/object_events.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/object_events.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system_proxy.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system_proxy.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pathfinding.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pathfinding.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pause_game_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pause_game_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/playable_custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/playable_custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/player_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/player_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_line_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_line_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preferences.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preferences.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preprocessor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preprocessor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preview_tileset_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preview_tileset_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/progress_bar.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/progress_bar.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rect_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rect_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rectangle_rotator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rectangle_rotator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rich_text_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rich_text_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/screen_handling.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/screen_handling.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollable_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollable_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollbar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollbar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/segment_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/segment_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/settings_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/settings_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/shared_memory_pipe.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/shared_memory_pipe.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/slider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/slider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/solid_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/solid_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sound.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/speech_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/speech_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats_server_main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats_server_main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_cache.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_cache.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_palette.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_palette.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/easy_svg.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/easy_svg.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_container.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_container.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_fwd.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_fwd.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_gradient.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_gradient.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_length.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_length.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_paint.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_paint.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_parse.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_parse.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_path_parse.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_path_parse.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_shapes.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_shapes.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_style.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_style.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_transform.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_transform.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sys.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sys.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_ai_player.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_ai_player.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_bot.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_bot.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_game.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_game.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_internal_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_internal_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_ipc_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_ipc_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_matchmaking_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_matchmaking_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_relay_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_relay_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server_base.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server_base.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/text_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/theme_imgui.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/theme_imgui.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/thread.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/thread.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tile_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tile_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tiled.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tiled.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tmx_reader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tmx_reader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tileset_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tileset_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tooltip.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tooltip.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tree_view_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tree_view_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/unit_test.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/unit_test.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_object_compiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_object_compiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_query.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_query.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_render_level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_render_level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/uuid.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/uuid.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_type_check.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_type_check.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/video_selections.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/video_selections.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/weather_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/weather_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget_factory.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget_factory.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/wml_formula_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/wml_formula_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_lexer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_lexer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_properties.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_properties.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_selector.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_selector.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_styles.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_styles.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_stylesheet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_stylesheet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_transition.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_transition.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/event_listener.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/event_listener.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/scrollable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/scrollable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/solid_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/solid_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_absolute_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_absolute_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_background_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_background_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_border_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_border_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_element_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_element_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_layout_engine.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_layout_engine.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_line_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_line_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_listitem_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_listitem_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_render_ctx.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_render_ctx.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_root_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_root_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_script_interface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_script_interface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_style_tree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_style_tree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xslider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xslider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )

--- a/buildsystem/cmake-includes/silence-warnings/04-extra/clang/02-sign-compare/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/04-extra/clang/02-sign-compare/CMakeLists.txt
@@ -2,1586 +2,1586 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ColorTransform.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ColorTransform.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/LayerBlitInfo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/LayerBlitInfo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ParticleSystemWidget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ParticleSystemWidget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/SceneObjectCallable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/SceneObjectCallable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/TextureObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/TextureObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_creator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_creator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_preview_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_preview_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/anura_shader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/anura_shader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/asserts.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/asserts.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/auto_update_window.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/auto_update_window.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/background.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/background.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/bar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/bar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/blur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/blur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/border_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/border_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/cairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/cairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/character_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/character_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/checkbox.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/checkbox.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/checksum.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/checksum.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/collision_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/collision_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/color_picker.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/color_picker.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/compress.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/compress.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/controls.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/controls.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/controls_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/controls_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/current_generator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/current_generator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/db_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/db_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/debug_console.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/debug_console.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/distortion.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/distortion.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/drag_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/drag_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_primitive.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_primitive.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_scene.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_scene.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dropdown_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dropdown_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_dialogs.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_dialogs.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_formula_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_formula_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_layers_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_layers_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_level_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_level_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_module_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_module_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_stats_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_stats_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_variable_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_variable_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/entity.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/entity.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/external_text_editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/external_text_editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_dom.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_dom.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_lib.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_lib.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/file_chooser_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/file_chooser_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/filesystem.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/filesystem.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_callable_definition.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_callable_definition.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_constants.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_constants.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function_registry.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function_registry.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_garbage_collector.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_garbage_collector.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_interface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_interface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_internal.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_internal.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_profiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_profiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_test.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_test.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_tokenizer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_tokenizer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_visualize_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_visualize_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_vm.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_vm.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/frame.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/framed_gui_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/framed_gui_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/game_registry.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/game_registry.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/geometry_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/geometry_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/grid_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/grid_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/group_property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/group_property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/gui_section.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/gui_section.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_helper.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_helper.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_loader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_loader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_mask.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_mask.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/tile_rules.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/tile_rules.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/http_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/http_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/http_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/http_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/image_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/image_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/input.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/input.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/joystick.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/joystick.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/json_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/json_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/key_button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/key_button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/AttributeSet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/AttributeSet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blend.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Blend.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blittable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Blittable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CameraObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CameraObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Canvas.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Canvas.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CanvasOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CanvasOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ClipScope.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ClipScope.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ClipScopeOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ClipScopeOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Color.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Color.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Cursor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Cursor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDevice.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDevice.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDeviceOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDeviceOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/EffectsOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/EffectsOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FboOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FboOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontDriver.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontDriver.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontFreetype.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontFreetype.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSDL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSDL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSTB.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSTB.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Gradients.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Gradients.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/LightObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/LightObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystem.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystem.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemAffectors.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemAffectors.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemEmitters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemEmitters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemParameters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemParameters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemUI.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemUI.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderQueue.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/RenderQueue.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderTarget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/RenderTarget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneGraph.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneGraph.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneNode.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneNode.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneTree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneTree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Scissor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Scissor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ScissorOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ScissorOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Shaders.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Shaders.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ShadersOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ShadersOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/StencilScope.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/StencilScope.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Surface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Surface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceBlur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceBlur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceSDL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceSDL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceScale.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceScale.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/TexPack.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/TexPack.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Texture.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Texture.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/TextureOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/TextureOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/UniformBufferOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/UniformBufferOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraph.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraph.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraphCairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraphCairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/WindowManager.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/WindowManager.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/language_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/language_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/layout_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/layout_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_logic.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_logic.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_runner.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_runner.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_solid_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_solid_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/light.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/light.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/load_level_nothread.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/load_level_nothread.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/loading_screen.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/loading_screen.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/message_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/message_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multi_tile_pattern.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multi_tile_pattern.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/object_events.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/object_events.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system_proxy.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system_proxy.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pathfinding.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pathfinding.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pause_game_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pause_game_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/playable_custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/playable_custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/player_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/player_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_line_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_line_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preferences.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preferences.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preprocessor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preprocessor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preview_tileset_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preview_tileset_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/progress_bar.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/progress_bar.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rect_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rect_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rectangle_rotator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rectangle_rotator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rich_text_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rich_text_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/screen_handling.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/screen_handling.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollable_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollable_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollbar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollbar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/segment_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/segment_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/settings_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/settings_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/slider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/slider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/solid_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/solid_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sound.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/speech_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/speech_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/string_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/string_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_cache.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_cache.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_palette.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_palette.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/easy_svg.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/easy_svg.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_container.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_container.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_gradient.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_gradient.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_paint.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_paint.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_parse.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_parse.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_shapes.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_shapes.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_style.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_style.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_transform.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_transform.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_ai_player.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_ai_player.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_bot.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_bot.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_game.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_game.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_internal_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_internal_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_ipc_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_ipc_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_matchmaking_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_matchmaking_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_relay_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_relay_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server_base.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server_base.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/text_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tile_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tile_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tiled.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tiled.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tmx_reader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tmx_reader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tileset_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tileset_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tooltip.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tooltip.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tree_view_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tree_view_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_object_compiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_object_compiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_query.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_query.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_render_level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_render_level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/video_selections.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/video_selections.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/weather_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/weather_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget_factory.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget_factory.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/wml_formula_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/wml_formula_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_lexer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_lexer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_properties.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_properties.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_selector.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_selector.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_styles.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_styles.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_stylesheet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_stylesheet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_transition.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_transition.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/event_listener.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/event_listener.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/scrollable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/scrollable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/solid_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/solid_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_absolute_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_absolute_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_background_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_background_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_border_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_border_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_element_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_element_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_layout_engine.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_layout_engine.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_line_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_line_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_listitem_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_listitem_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_render_ctx.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_render_ctx.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_root_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_root_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_script_interface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_script_interface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_style_tree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_style_tree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xslider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xslider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-sign-compare"
 )

--- a/buildsystem/cmake-includes/silence-warnings/04-extra/clang/03-deprecated-copy-with-user-provided-copy/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/04-extra/clang/03-deprecated-copy-with-user-provided-copy/CMakeLists.txt
@@ -2,13 +2,13 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ParticleSystemWidget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ParticleSystemWidget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-copy-with-user-provided-copy"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CameraObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CameraObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-copy-with-user-provided-copy"
 )

--- a/buildsystem/cmake-includes/silence-warnings/04-extra/clang/04-deprecated-copy/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/04-extra/clang/04-deprecated-copy/CMakeLists.txt
@@ -2,13 +2,13 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ParticleSystemWidget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ParticleSystemWidget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-copy"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CameraObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CameraObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-copy"
 )

--- a/buildsystem/cmake-includes/silence-warnings/04-extra/clang/05-missing-field-initializers/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/04-extra/clang/05-missing-field-initializers/CMakeLists.txt
@@ -2,7 +2,7 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-missing-field-initializers"
 )

--- a/buildsystem/cmake-includes/silence-warnings/04-extra/gcc/01-unused-parameter/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/04-extra/gcc/01-unused-parameter/CMakeLists.txt
@@ -2,1765 +2,1765 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ColorTransform.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ColorTransform.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/LayerBlitInfo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/LayerBlitInfo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ParticleSystemWidget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ParticleSystemWidget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/SceneObjectCallable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/SceneObjectCallable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/TextureObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/TextureObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/VoronoiDiagramGenerator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/VoronoiDiagramGenerator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/achievements.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/achievements.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_creator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_creator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_preview_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_preview_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/anura_shader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/anura_shader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/asserts.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/asserts.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/auto_update_window.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/auto_update_window.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/background.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/background.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/bar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/bar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/blur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/blur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/border_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/border_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/cairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/cairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/character_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/character_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/checkbox.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/checkbox.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/checksum.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/checksum.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/clipboard.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/clipboard.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/collision_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/collision_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/color_picker.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/color_picker.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/compress.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/compress.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/controls.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/controls.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/controls_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/controls_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/current_generator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/current_generator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/db_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/db_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/debug_console.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/debug_console.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/difficulty.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/difficulty.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/distortion.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/distortion.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/drag_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/drag_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_primitive.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_primitive.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_scene.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_scene.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dropdown_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dropdown_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_dialogs.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_dialogs.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_formula_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_formula_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_layers_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_layers_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_level_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_level_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_module_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_module_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_stats_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_stats_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_variable_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_variable_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/entity.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/entity.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/external_text_editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/external_text_editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_dom.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_dom.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_lib.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_lib.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/file_chooser_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/file_chooser_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/filesystem.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/filesystem.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_callable_definition.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_callable_definition.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_callable_visitor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_callable_visitor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_constants.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_constants.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function_registry.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function_registry.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_garbage_collector.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_garbage_collector.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_interface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_interface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_internal.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_internal.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_profiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_profiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_test.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_test.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_variable_storage.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_variable_storage.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_visualize_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_visualize_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_vm.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_vm.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/frame.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/framed_gui_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/framed_gui_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ft_iface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ft_iface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/game_registry.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/game_registry.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/geometry_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/geometry_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/grid_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/grid_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/group_property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/group_property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/gui_section.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/gui_section.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_helper.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_helper.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_loader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_loader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_mask.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_mask.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/tile_rules.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/tile_rules.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/http_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/http_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/http_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/http_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/i18n.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/i18n.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/image_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/image_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/input.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/input.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/joystick.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/joystick.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/json_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/json_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/key_button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/key_button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/AttributeSet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/AttributeSet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/AttributeSetOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/AttributeSetOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blend.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Blend.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/BlendModeScope.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/BlendModeScope.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/BlendOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/BlendOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blittable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Blittable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CameraObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CameraObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Canvas.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Canvas.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CanvasOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CanvasOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ClipScope.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ClipScope.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ClipScopeOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ClipScopeOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Color.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Color.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ColorScope.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ColorScope.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Cursor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Cursor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Depth.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Depth.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDevice.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDevice.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDeviceOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDeviceOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/EffectsOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/EffectsOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FboOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FboOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontDriver.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontDriver.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontFreetype.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontFreetype.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSDL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSDL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSTB.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSTB.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Gradients.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Gradients.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/LightObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/LightObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystem.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystem.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemAffectors.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemAffectors.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemEmitters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemEmitters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemParameters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemParameters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemUI.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemUI.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderQueue.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/RenderQueue.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderTarget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/RenderTarget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneGraph.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneGraph.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneNode.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneNode.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneParameters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneParameters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneTree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneTree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Scissor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Scissor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ScissorOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ScissorOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Shaders.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Shaders.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ShadersOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ShadersOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/StencilScope.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/StencilScope.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Surface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Surface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceBlur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceBlur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceSDL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceSDL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceScale.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceScale.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/TexPack.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/TexPack.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Texture.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Texture.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/TextureOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/TextureOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/UniformBufferOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/UniformBufferOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraph.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraph.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraphCairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraphCairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/WindowManager.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/WindowManager.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/language_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/language_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/layout_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/layout_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_logic.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_logic.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_runner.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_runner.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_solid_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_solid_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/light.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/light.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/load_level_nothread.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/load_level_nothread.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/loading_screen.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/loading_screen.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/logger.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/logger.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/md5.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/md5.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/message_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/message_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multi_tile_pattern.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multi_tile_pattern.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/object_events.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/object_events.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system_proxy.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system_proxy.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pathfinding.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pathfinding.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pause_game_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pause_game_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/playable_custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/playable_custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/player_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/player_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_line_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_line_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preferences.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preferences.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preprocessor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preprocessor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preview_tileset_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preview_tileset_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/progress_bar.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/progress_bar.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rect_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rect_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rectangle_rotator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rectangle_rotator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rich_text_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rich_text_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/screen_handling.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/screen_handling.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollable_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollable_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollbar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollbar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/segment_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/segment_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/settings_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/settings_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/shared_memory_pipe.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/shared_memory_pipe.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/slider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/slider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/solid_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/solid_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sound.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/speech_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/speech_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats_server_main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats_server_main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_cache.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_cache.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_palette.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_palette.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/easy_svg.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/easy_svg.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_container.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_container.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_fwd.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_fwd.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_gradient.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_gradient.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_length.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_length.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_paint.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_paint.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_parse.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_parse.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_path_parse.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_path_parse.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_shapes.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_shapes.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_style.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_style.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_transform.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_transform.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sys.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sys.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_ai_player.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_ai_player.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_bot.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_bot.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_game.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_game.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_internal_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_internal_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_ipc_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_ipc_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_matchmaking_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_matchmaking_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_relay_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_relay_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server_base.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server_base.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/text_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/theme_imgui.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/theme_imgui.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/thread.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/thread.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tile_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tile_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tiled.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tiled.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tmx_reader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tmx_reader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tileset_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tileset_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tooltip.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tooltip.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tree_view_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tree_view_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/unit_test.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/unit_test.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_object_compiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_object_compiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_query.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_query.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_render_level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_render_level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/uuid.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/uuid.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_type_check.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_type_check.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/video_selections.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/video_selections.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/weather_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/weather_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget_factory.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget_factory.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/wml_formula_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/wml_formula_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_lexer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_lexer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_properties.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_properties.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_selector.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_selector.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_styles.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_styles.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_stylesheet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_stylesheet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_transition.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_transition.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/event_listener.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/event_listener.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/scrollable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/scrollable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/solid_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/solid_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_absolute_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_absolute_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_background_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_background_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_border_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_border_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_element_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_element_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_layout_engine.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_layout_engine.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_line_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_line_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_listitem_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_listitem_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_render_ctx.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_render_ctx.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_root_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_root_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_script_interface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_script_interface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_style_tree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_style_tree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xslider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xslider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-unused-parameter"
 )

--- a/buildsystem/cmake-includes/silence-warnings/04-extra/gcc/02-implicit-fallthrough/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/04-extra/gcc/02-implicit-fallthrough/CMakeLists.txt
@@ -2,79 +2,79 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-implicit-fallthrough"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_tokenizer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_tokenizer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-implicit-fallthrough"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/grid_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/grid_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-implicit-fallthrough"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/json_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/json_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-implicit-fallthrough"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/TextureOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/TextureOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-implicit-fallthrough"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_runner.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_runner.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-implicit-fallthrough"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-implicit-fallthrough"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_gradient.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_gradient.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-implicit-fallthrough"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_length.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_length.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-implicit-fallthrough"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_shapes.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_shapes.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-implicit-fallthrough"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_style.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_style.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-implicit-fallthrough"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/text_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-implicit-fallthrough"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_styles.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_styles.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-implicit-fallthrough"
 )

--- a/buildsystem/cmake-includes/silence-warnings/04-extra/gcc/03-extra/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/04-extra/gcc/03-extra/CMakeLists.txt
@@ -3,49 +3,49 @@
 
 # XXX - base class should be explicitly initialized in the copy constructor
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_preview_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_preview_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra"
 )
 
 # XXX - base class should be explicitly initialized in the copy constructor
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/anura_shader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/anura_shader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra"
 )
 
 # XXX - base class should be explicitly initialized in the copy constructor
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra"
 )
 
 # XXX - base class should be explicitly initialized in the copy constructor
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra"
 )
 
 # XXX - base class should be explicitly initialized in the copy constructor
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/AttributeSet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/AttributeSet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra"
 )
 
 # XXX - base class should be explicitly initialized in the copy constructor
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Texture.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Texture.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra"
 )
 
 # XXX - base class should be explicitly initialized in the copy constructor
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra"
 )

--- a/buildsystem/cmake-includes/silence-warnings/04-extra/gcc/04-dangling-reference/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/04-extra/gcc/04-dangling-reference/CMakeLists.txt
@@ -2,37 +2,37 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/cairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/cairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-dangling-reference"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-dangling-reference"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-dangling-reference"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-dangling-reference"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sound.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-dangling-reference"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-dangling-reference"
 )

--- a/buildsystem/cmake-includes/silence-warnings/04-extra/gcc/05-deprecated-copy/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/04-extra/gcc/05-deprecated-copy/CMakeLists.txt
@@ -2,25 +2,25 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ParticleSystemWidget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ParticleSystemWidget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-copy"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-copy"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/text_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-copy"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tile_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tile_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-deprecated-copy"
 )

--- a/buildsystem/cmake-includes/silence-warnings/04-extra/gcc/06-missing-field-initializers/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/04-extra/gcc/06-missing-field-initializers/CMakeLists.txt
@@ -2,7 +2,7 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-missing-field-initializers"
 )

--- a/buildsystem/cmake-includes/silence-warnings/04-extra/gcc/07-type-limits/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/04-extra/gcc/07-type-limits/CMakeLists.txt
@@ -2,7 +2,7 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CameraObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CameraObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-type-limits"
 )

--- a/buildsystem/cmake-includes/silence-warnings/05-pedantic/clang/01-gnu-anonymous-struct/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/05-pedantic/clang/01-gnu-anonymous-struct/CMakeLists.txt
@@ -2,1291 +2,1291 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/LayerBlitInfo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/LayerBlitInfo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ParticleSystemWidget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ParticleSystemWidget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/TextureObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/TextureObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_creator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_creator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_preview_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_preview_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/anura_shader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/anura_shader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/asserts.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/asserts.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/auto_update_window.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/auto_update_window.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/background.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/background.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/bar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/bar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/blur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/blur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/border_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/border_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/cairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/cairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/character_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/character_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/checkbox.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/checkbox.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/collision_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/collision_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/color_picker.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/color_picker.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/controls_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/controls_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/current_generator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/current_generator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/debug_console.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/debug_console.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/distortion.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/distortion.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/drag_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/drag_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_primitive.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_primitive.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_scene.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_scene.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dropdown_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dropdown_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_dialogs.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_dialogs.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_formula_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_formula_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_layers_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_layers_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_level_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_level_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_module_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_module_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_stats_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_stats_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/entity.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/entity.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/external_text_editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/external_text_editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_dom.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_dom.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/file_chooser_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/file_chooser_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_constants.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_constants.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_profiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_profiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_visualize_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_visualize_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/frame.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/framed_gui_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/framed_gui_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/geometry_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/geometry_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/grid_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/grid_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/group_property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/group_property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/gui_section.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/gui_section.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_helper.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_helper.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_loader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_loader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_mask.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_mask.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/tile_rules.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/tile_rules.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/image_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/image_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/input.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/input.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/json_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/json_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/key_button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/key_button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/AttributeSet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/AttributeSet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blend.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Blend.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blittable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Blittable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CameraObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CameraObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Canvas.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Canvas.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CanvasOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CanvasOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ClipScope.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ClipScope.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ClipScopeOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ClipScopeOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Cursor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Cursor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDevice.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDevice.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDeviceOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDeviceOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/EffectsOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/EffectsOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FboOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FboOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontDriver.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontDriver.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontFreetype.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontFreetype.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSDL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSDL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSTB.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSTB.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Gradients.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Gradients.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/LightObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/LightObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystem.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystem.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemAffectors.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemAffectors.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemEmitters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemEmitters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemUI.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemUI.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderQueue.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/RenderQueue.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderTarget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/RenderTarget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneGraph.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneGraph.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneNode.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneNode.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneTree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneTree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Scissor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Scissor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ScissorOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ScissorOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Shaders.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Shaders.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ShadersOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ShadersOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/StencilScope.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/StencilScope.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Surface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Surface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceBlur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceBlur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceSDL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceSDL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceScale.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceScale.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/TexPack.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/TexPack.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Texture.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Texture.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/TextureOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/TextureOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/UniformBufferOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/UniformBufferOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraph.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraph.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraphCairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraphCairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/WindowManager.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/WindowManager.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/language_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/language_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/layout_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/layout_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_logic.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_logic.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_runner.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_runner.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/light.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/light.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/load_level_nothread.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/load_level_nothread.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/loading_screen.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/loading_screen.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/message_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/message_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multi_tile_pattern.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multi_tile_pattern.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system_proxy.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system_proxy.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pathfinding.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pathfinding.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pause_game_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pause_game_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/playable_custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/playable_custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/player_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/player_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_line_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_line_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preferences.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preferences.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preview_tileset_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preview_tileset_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/progress_bar.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/progress_bar.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rect_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rect_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rectangle_rotator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rectangle_rotator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rich_text_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rich_text_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/screen_handling.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/screen_handling.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollable_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollable_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollbar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollbar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/segment_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/segment_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/settings_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/settings_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/slider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/slider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/solid_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/solid_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sound.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/speech_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/speech_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_cache.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_cache.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_palette.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_palette.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/easy_svg.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/easy_svg.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_container.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_container.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_gradient.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_gradient.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_paint.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_paint.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_parse.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_parse.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_shapes.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_shapes.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_style.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_style.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_transform.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_transform.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/text_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tile_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tile_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tiled.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tiled.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tmx_reader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tmx_reader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tileset_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tileset_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tooltip.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tooltip.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tree_view_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tree_view_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_object_compiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_object_compiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_render_level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_render_level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/video_selections.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/video_selections.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/weather_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/weather_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget_factory.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget_factory.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_properties.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_properties.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_selector.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_selector.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_styles.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_styles.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_stylesheet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_stylesheet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_transition.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_transition.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/event_listener.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/event_listener.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/scrollable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/scrollable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/solid_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/solid_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_absolute_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_absolute_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_background_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_background_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_border_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_border_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_element_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_element_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_layout_engine.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_layout_engine.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_line_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_line_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_listitem_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_listitem_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_render_ctx.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_render_ctx.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_root_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_root_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_script_interface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_script_interface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_style_tree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_style_tree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xslider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xslider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-gnu-anonymous-struct"
 )

--- a/buildsystem/cmake-includes/silence-warnings/05-pedantic/clang/02-nested-anon-types/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/05-pedantic/clang/02-nested-anon-types/CMakeLists.txt
@@ -2,1291 +2,1291 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/LayerBlitInfo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/LayerBlitInfo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ParticleSystemWidget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ParticleSystemWidget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/TextureObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/TextureObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_creator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_creator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_preview_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_preview_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/anura_shader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/anura_shader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/asserts.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/asserts.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/auto_update_window.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/auto_update_window.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/background.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/background.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/bar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/bar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/blur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/blur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/border_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/border_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/cairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/cairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/character_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/character_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/checkbox.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/checkbox.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/collision_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/collision_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/color_picker.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/color_picker.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/controls_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/controls_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/current_generator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/current_generator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/debug_console.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/debug_console.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/distortion.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/distortion.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/drag_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/drag_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_primitive.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_primitive.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_scene.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_scene.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dropdown_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dropdown_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_dialogs.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_dialogs.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_formula_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_formula_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_layers_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_layers_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_level_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_level_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_module_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_module_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_stats_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_stats_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/entity.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/entity.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/external_text_editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/external_text_editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_dom.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_dom.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/file_chooser_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/file_chooser_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_constants.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_constants.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_profiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_profiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_visualize_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_visualize_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/frame.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/framed_gui_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/framed_gui_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/geometry_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/geometry_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/grid_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/grid_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/group_property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/group_property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/gui_section.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/gui_section.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_helper.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_helper.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_loader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_loader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_mask.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_mask.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/tile_rules.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/tile_rules.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/image_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/image_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/input.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/input.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/json_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/json_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/key_button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/key_button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/AttributeSet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/AttributeSet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blend.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Blend.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blittable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Blittable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CameraObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CameraObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Canvas.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Canvas.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CanvasOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CanvasOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ClipScope.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ClipScope.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ClipScopeOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ClipScopeOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Cursor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Cursor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDevice.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDevice.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDeviceOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDeviceOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/EffectsOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/EffectsOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FboOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FboOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontDriver.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontDriver.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontFreetype.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontFreetype.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSDL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSDL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSTB.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSTB.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Gradients.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Gradients.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/LightObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/LightObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystem.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystem.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemAffectors.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemAffectors.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemEmitters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemEmitters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemUI.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemUI.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderQueue.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/RenderQueue.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderTarget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/RenderTarget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneGraph.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneGraph.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneNode.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneNode.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneTree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneTree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Scissor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Scissor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ScissorOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ScissorOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Shaders.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Shaders.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ShadersOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ShadersOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/StencilScope.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/StencilScope.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Surface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Surface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceBlur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceBlur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceSDL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceSDL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceScale.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceScale.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/TexPack.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/TexPack.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Texture.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Texture.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/TextureOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/TextureOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/UniformBufferOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/UniformBufferOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraph.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraph.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraphCairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraphCairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/WindowManager.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/WindowManager.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/language_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/language_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/layout_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/layout_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_logic.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_logic.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_runner.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_runner.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/light.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/light.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/load_level_nothread.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/load_level_nothread.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/loading_screen.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/loading_screen.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/message_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/message_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multi_tile_pattern.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multi_tile_pattern.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system_proxy.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system_proxy.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pathfinding.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pathfinding.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pause_game_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pause_game_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/playable_custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/playable_custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/player_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/player_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_line_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_line_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preferences.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preferences.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preview_tileset_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preview_tileset_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/progress_bar.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/progress_bar.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rect_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rect_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rectangle_rotator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rectangle_rotator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rich_text_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rich_text_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/screen_handling.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/screen_handling.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollable_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollable_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollbar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollbar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/segment_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/segment_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/settings_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/settings_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/slider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/slider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/solid_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/solid_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sound.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/speech_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/speech_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_cache.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_cache.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_palette.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_palette.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/easy_svg.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/easy_svg.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_container.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_container.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_gradient.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_gradient.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_paint.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_paint.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_parse.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_parse.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_shapes.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_shapes.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_style.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_style.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_transform.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_transform.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/text_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tile_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tile_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tiled.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tiled.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tmx_reader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tmx_reader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tileset_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tileset_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tooltip.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tooltip.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tree_view_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tree_view_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_object_compiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_object_compiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_render_level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_render_level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/video_selections.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/video_selections.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/weather_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/weather_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget_factory.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget_factory.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_properties.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_properties.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_selector.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_selector.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_styles.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_styles.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_stylesheet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_stylesheet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_transition.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_transition.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/event_listener.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/event_listener.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/scrollable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/scrollable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/solid_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/solid_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_absolute_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_absolute_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_background_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_background_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_border_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_border_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_element_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_element_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_layout_engine.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_layout_engine.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_line_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_line_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_listitem_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_listitem_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_render_ctx.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_render_ctx.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_root_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_root_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_script_interface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_script_interface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_style_tree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_style_tree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xslider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xslider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-nested-anon-types"
 )

--- a/buildsystem/cmake-includes/silence-warnings/05-pedantic/clang/03-extra-semi/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/05-pedantic/clang/03-extra-semi/CMakeLists.txt
@@ -2,829 +2,829 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ParticleSystemWidget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ParticleSystemWidget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/TextureObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/TextureObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_creator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_creator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_preview_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_preview_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/anura_shader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/anura_shader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/asserts.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/asserts.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/auto_update_window.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/auto_update_window.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/background.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/background.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/bar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/bar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/blur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/blur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/border_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/border_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/cairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/cairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/character_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/character_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/checkbox.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/checkbox.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/collision_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/collision_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/color_picker.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/color_picker.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/compress.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/compress.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/controls.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/controls.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/controls_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/controls_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/db_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/db_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/debug_console.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/debug_console.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/distortion.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/distortion.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/drag_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/drag_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_primitive.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_primitive.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_scene.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_scene.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dropdown_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dropdown_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_dialogs.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_dialogs.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_formula_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_formula_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_layers_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_layers_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_level_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_level_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_module_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_module_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_stats_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_stats_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/entity.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/entity.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/external_text_editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/external_text_editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_dom.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_dom.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_lib.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_lib.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/file_chooser_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/file_chooser_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_constants.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_constants.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_profiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_profiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_visualize_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_visualize_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/frame.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/geometry_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/geometry_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/grid_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/grid_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/group_property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/group_property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_loader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_loader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_mask.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_mask.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/tile_rules.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/tile_rules.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/http_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/http_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/http_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/http_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/image_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/image_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/joystick.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/joystick.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/json_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/json_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/key_button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/key_button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystem.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystem.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemAffectors.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemAffectors.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemEmitters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemEmitters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemParameters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemParameters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemUI.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemUI.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneParameters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneParameters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/language_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/language_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/layout_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/layout_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_logic.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_logic.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_runner.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_runner.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/light.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/light.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/load_level_nothread.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/load_level_nothread.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/loading_screen.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/loading_screen.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multi_tile_pattern.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multi_tile_pattern.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system_proxy.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system_proxy.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pathfinding.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pathfinding.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pause_game_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pause_game_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/playable_custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/playable_custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/player_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/player_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_line_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_line_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preferences.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preferences.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preview_tileset_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preview_tileset_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/progress_bar.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/progress_bar.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rich_text_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rich_text_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollable_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollable_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollbar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollbar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/segment_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/segment_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/slider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/slider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sound.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/speech_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/speech_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_ai_player.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_ai_player.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_bot.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_bot.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_game.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_game.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_internal_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_internal_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_ipc_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_ipc_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_matchmaking_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_matchmaking_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_relay_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_relay_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server_base.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server_base.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/text_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tile_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tile_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tmx_reader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tmx_reader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tileset_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tileset_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tree_view_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tree_view_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_object_compiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_object_compiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_render_level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_render_level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/video_selections.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/video_selections.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/weather_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/weather_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget_factory.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget_factory.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-extra-semi"
 )

--- a/buildsystem/cmake-includes/silence-warnings/05-pedantic/clang/04-format-pedantic/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/05-pedantic/clang/04-format-pedantic/CMakeLists.txt
@@ -2,31 +2,31 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-format-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_garbage_collector.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_garbage_collector.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-format-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system_proxy.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system_proxy.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-format-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_object_compiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_object_compiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-format-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-format-pedantic"
 )

--- a/buildsystem/cmake-includes/silence-warnings/05-pedantic/clang/05-vla-extension/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/05-pedantic/clang/05-vla-extension/CMakeLists.txt
@@ -2,7 +2,7 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/asserts.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/asserts.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-vla-extension"
 )

--- a/buildsystem/cmake-includes/silence-warnings/05-pedantic/gcc/01-pedantic/CMakeLists.txt
+++ b/buildsystem/cmake-includes/silence-warnings/05-pedantic/gcc/01-pedantic/CMakeLists.txt
@@ -2,1441 +2,1441 @@
 # XXX - The leading spaces in this file are meaningful for string concatenation!
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/LayerBlitInfo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/LayerBlitInfo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ParticleSystemWidget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ParticleSystemWidget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/TextureObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/TextureObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_creator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_creator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_preview_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_preview_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/animation_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/animation_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/anura_shader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/anura_shader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/asserts.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/asserts.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/auto_update_window.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/auto_update_window.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/background.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/background.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/bar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/bar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/blur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/blur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/border_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/border_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/cairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/cairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/character_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/character_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/checkbox.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/checkbox.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/code_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/code_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/collision_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/collision_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/color_picker.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/color_picker.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/compress.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/compress.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/controls.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/controls.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/controls_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/controls_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/current_generator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/current_generator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/custom_object_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/custom_object_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/db_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/db_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/debug_console.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/debug_console.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/distortion.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/distortion.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/drag_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/drag_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_primitive.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_primitive.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_scene.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_scene.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/draw_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/draw_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/dropdown_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/dropdown_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_dialogs.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_dialogs.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_formula_functions.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_formula_functions.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_layers_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_layers_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_level_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_level_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_module_properties_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_module_properties_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/editor_stats_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/editor_stats_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/entity.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/entity.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/external_text_editor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/external_text_editor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_dom.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_dom.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/ffl_lib.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/ffl_lib.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/file_chooser_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/file_chooser_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_constants.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_constants.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_function.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_function.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_garbage_collector.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_garbage_collector.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_profiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_profiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_test.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_test.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/formula_visualize_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/formula_visualize_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/frame.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/frame.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/framed_gui_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/framed_gui_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/geometry_callable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/geometry_callable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/graphical_font_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/graphical_font_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/grid_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/grid_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/group_property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/group_property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/gui_section.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/gui_section.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_helper.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_helper.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_loader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_loader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_mask.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_mask.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/hex_tile.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/hex_tile.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/hex/tile_rules.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/hex/tile_rules.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/http_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/http_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/http_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/http_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/image_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/image_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/input.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/input.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/joystick.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/joystick.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/json_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/json_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/key_button.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/key_button.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/AttributeSet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/AttributeSet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blend.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Blend.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Blittable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Blittable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CameraObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CameraObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Canvas.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Canvas.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/CanvasOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/CanvasOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ClipScope.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ClipScope.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ClipScopeOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ClipScopeOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Cursor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Cursor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDevice.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDevice.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/DisplayDeviceOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/DisplayDeviceOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/EffectsOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/EffectsOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FboOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FboOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Font.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Font.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontDriver.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontDriver.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontFreetype.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontFreetype.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSDL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSDL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/FontSTB.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/FontSTB.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Gradients.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Gradients.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/LightObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/LightObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystem.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystem.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemAffectors.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemAffectors.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemEmitters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemEmitters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemParameters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemParameters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ParticleSystemUI.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ParticleSystemUI.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderQueue.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/RenderQueue.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/RenderTarget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/RenderTarget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneGraph.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneGraph.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneNode.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneNode.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneObject.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneObject.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneParameters.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneParameters.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SceneTree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SceneTree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Scissor.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Scissor.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ScissorOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ScissorOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Shaders.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Shaders.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/ShadersOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/ShadersOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/StencilScope.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/StencilScope.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Surface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Surface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceBlur.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceBlur.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceSDL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceSDL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/SurfaceScale.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/SurfaceScale.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/TexPack.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/TexPack.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/Texture.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/Texture.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/TextureOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/TextureOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/UniformBufferOGL.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/UniformBufferOGL.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraph.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraph.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/VGraphCairo.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/VGraphCairo.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/kre/WindowManager.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/kre/WindowManager.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/language_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/language_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/layout_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/layout_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_logic.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_logic.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/level_runner.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/level_runner.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/light.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/light.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/load_level_nothread.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/load_level_nothread.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/loading_screen.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/loading_screen.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/main.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/main.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/message_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/message_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/module_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/module_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multi_tile_pattern.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multi_tile_pattern.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/multiplayer.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/multiplayer.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/particle_system_proxy.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/particle_system_proxy.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pathfinding.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pathfinding.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/pause_game_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/pause_game_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/playable_custom_object.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/playable_custom_object.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/player_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/player_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_line_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_line_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/poly_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/poly_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preferences.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preferences.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/preview_tileset_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/preview_tileset_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/progress_bar.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/progress_bar.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/property_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/property_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rect_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rect_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rectangle_rotator.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rectangle_rotator.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/rich_text_label.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/rich_text_label.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/screen_handling.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/screen_handling.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollable_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollable_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/scrollbar_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/scrollbar_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/segment_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/segment_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/settings_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/settings_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/slider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/slider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/solid_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/solid_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/sound.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/sound.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/speech_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/speech_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/stats.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/stats.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_cache.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_cache.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_palette.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_palette.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/surface_utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/surface_utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/easy_svg.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/easy_svg.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_container.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_container.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_gradient.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_gradient.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_paint.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_paint.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_parse.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_parse.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_shapes.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_shapes.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_style.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_style.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/svg/svg_transform.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/svg/svg_transform.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_ai_player.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_ai_player.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_bot.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_bot.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_game.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_game.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_internal_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_internal_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_internal_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_ipc_client.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_ipc_client.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_matchmaking_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_matchmaking_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_relay_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_relay_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_server_base.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_server_base.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tbs_web_server.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tbs_web_server.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/text_editor_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/text_editor_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tile_map.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tile_map.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tiled.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tiled.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tiled/tmx_reader.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tiled/tmx_reader.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tileset_editor_dialog.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tileset_editor_dialog.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tooltip.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tooltip.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/tree_view_widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/tree_view_widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_object_compiler.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_object_compiler.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utility_render_level.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utility_render_level.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/utils.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/utils.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/variant_type.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/variant_type.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/video_selections.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/video_selections.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/water_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/water_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/weather_particle_system.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/weather_particle_system.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/widget_factory.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/widget_factory.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_properties.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_properties.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_selector.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_selector.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_styles.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_styles.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_stylesheet.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_stylesheet.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/css_transition.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/css_transition.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/event_listener.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/event_listener.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/scrollable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/scrollable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/solid_renderable.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/solid_renderable.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_absolute_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_absolute_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_background_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_background_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_border_info.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_border_info.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_element.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_element.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_block_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_block_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_inline_element_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_inline_element_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_layout_engine.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_layout_engine.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_line_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_line_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_listitem_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_listitem_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_parser.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_parser.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_render_ctx.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_render_ctx.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_root_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_root_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_script_interface.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_script_interface.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_style_tree.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_style_tree.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_box.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_box.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xhtml_text_node.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xhtml_text_node.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )
 
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/xhtml/xslider.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/xhtml/xslider.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-pedantic"
 )

--- a/buildsystem/linux-dynamic/CMakeLists.txt
+++ b/buildsystem/linux-dynamic/CMakeLists.txt
@@ -2,7 +2,9 @@
 
 # 3.12 added add_compile_definitions
 # 3.14 added FetchContent
-cmake_minimum_required(VERSION 3.14)
+# 3.19 added presets v1: we use configurePresets
+# XXX - We cannot take this further than 3.23 as that's what ships in the Steam Sniper SDK!
+cmake_minimum_required(VERSION 3.19)
 
 if(DEFINED ENV{CXX})
   message("")
@@ -23,7 +25,7 @@ endif()
 set(
     CMAKE_MODULE_PATH
     ${CMAKE_MODULE_PATH}
-    "${CMAKE_BINARY_DIR}/buildsystem/cmake-includes/modules"
+    "${CMAKE_SOURCE_DIR}/../cmake-includes/modules"
 )
 
 # END CMake setup
@@ -32,6 +34,9 @@ set(
 
 # Build target for CXX project "anura"
 project(anura LANGUAGES CXX)
+
+# For running tests through CTest
+enable_testing()
 
 # Default to doing parallel LTO for Release builds, do thin LTO on Clang
 if (CMAKE_BUILD_TYPE MATCHES Release)
@@ -58,7 +63,7 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/ocornut/imgui.git
     GIT_TAG d4ddc46e7773e9a9b68f965d007968f35ca4e09a # https://github.com/ocornut/imgui/releases/tag/v1.89.7
     GIT_SHALLOW TRUE
-    SOURCE_DIR "${CMAKE_BINARY_DIR}/src/imgui"
+    SOURCE_DIR "${CMAKE_SOURCE_DIR}/build/src/imgui"
     SOURCE_SUBDIR purposefully-empty-to-skip-build
 )
 
@@ -70,7 +75,7 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/g-truc/glm.git
     GIT_TAG 33b0eb9fa336ffd8551024b1d2690e418014553b # https://github.com/g-truc/glm/releases/tag/1.0.0
     GIT_SHALLOW TRUE
-    SOURCE_DIR "${CMAKE_BINARY_DIR}/src/glm"
+    SOURCE_DIR "${CMAKE_SOURCE_DIR}/build/src/glm"
     SOURCE_SUBDIR purposefully-empty-to-skip-build
 )
 
@@ -86,18 +91,18 @@ endif(CCACHE)
 file(
     GLOB
     anura_SRC
-    "${CMAKE_BINARY_DIR}/src/*.cpp"
-    "${CMAKE_BINARY_DIR}/src/hex/*.cpp"
-    "${CMAKE_BINARY_DIR}/src/imgui/imgui_draw.cpp"
-    "${CMAKE_BINARY_DIR}/src/imgui/imgui_tables.cpp"
-    "${CMAKE_BINARY_DIR}/src/imgui/imgui_widgets.cpp"
-    "${CMAKE_BINARY_DIR}/src/imgui/imgui.cpp"
-    "${CMAKE_BINARY_DIR}/src/imgui_additions/*.cpp"
-    "${CMAKE_BINARY_DIR}/src/kre/*.cpp"
-    "${CMAKE_BINARY_DIR}/src/svg/*.cpp"
-    "${CMAKE_BINARY_DIR}/src/tiled/*.cpp"
-    "${CMAKE_BINARY_DIR}/src/treetree/*.cpp"
-    "${CMAKE_BINARY_DIR}/src/xhtml/*.cpp"
+    "${CMAKE_SOURCE_DIR}/build/src/imgui/imgui_draw.cpp"
+    "${CMAKE_SOURCE_DIR}/build/src/imgui/imgui_tables.cpp"
+    "${CMAKE_SOURCE_DIR}/build/src/imgui/imgui_widgets.cpp"
+    "${CMAKE_SOURCE_DIR}/build/src/imgui/imgui.cpp"
+    "${CMAKE_SOURCE_DIR}/../../src/*.cpp"
+    "${CMAKE_SOURCE_DIR}/../../src/hex/*.cpp"
+    "${CMAKE_SOURCE_DIR}/../../src/imgui_additions/*.cpp"
+    "${CMAKE_SOURCE_DIR}/../../src/kre/*.cpp"
+    "${CMAKE_SOURCE_DIR}/../../src/svg/*.cpp"
+    "${CMAKE_SOURCE_DIR}/../../src/tiled/*.cpp"
+    "${CMAKE_SOURCE_DIR}/../../src/treetree/*.cpp"
+    "${CMAKE_SOURCE_DIR}/../../src/xhtml/*.cpp"
 )
 
 # Configure compiling against system provided libraries
@@ -137,16 +142,16 @@ find_package(Cairo REQUIRED)
 # Add the headers
 # XXX - Unknown as of 2023-08 why only Freetype ft2build and SLD2 are needed
 include_directories(
-    "${CMAKE_BINARY_DIR}/src"
-    "${CMAKE_BINARY_DIR}/src/glm"
-    "${CMAKE_BINARY_DIR}/src/hex"
-    "${CMAKE_BINARY_DIR}/src/imgui"
-    "${CMAKE_BINARY_DIR}/src/imgui_additions"
-    "${CMAKE_BINARY_DIR}/src/kre"
-    "${CMAKE_BINARY_DIR}/src/svg"
-    "${CMAKE_BINARY_DIR}/src/tiled"
-    "${CMAKE_BINARY_DIR}/src/treetree"
-    "${CMAKE_BINARY_DIR}/src/xhtml"
+    "${CMAKE_SOURCE_DIR}/build/src/glm"
+    "${CMAKE_SOURCE_DIR}/build/src/imgui"
+    "${CMAKE_SOURCE_DIR}/../../src"
+    "${CMAKE_SOURCE_DIR}/../../src/hex"
+    "${CMAKE_SOURCE_DIR}/../../src/imgui_additions"
+    "${CMAKE_SOURCE_DIR}/../../src/kre"
+    "${CMAKE_SOURCE_DIR}/../../src/svg"
+    "${CMAKE_SOURCE_DIR}/../../src/tiled"
+    "${CMAKE_SOURCE_DIR}/../../src/treetree"
+    "${CMAKE_SOURCE_DIR}/../../src/xhtml"
     "${FREETYPE_INCLUDE_DIR_ft2build}"
     "${SDL2_INCLUDE_DIR}"
 )
@@ -187,7 +192,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
 
 # Inject our own imgui config for our own vector operations
-add_compile_definitions(IMGUI_USER_CONFIG="${CMAKE_BINARY_DIR}/src/imgui_additions/imconfig_anura.h")
+add_compile_definitions(IMGUI_USER_CONFIG="${CMAKE_SOURCE_DIR}/../../src/imgui_additions/imconfig_anura.h")
 
 if (CMAKE_BUILD_TYPE MATCHES Release)
     # Turn all things debug, like assertions, off for a release build
@@ -210,7 +215,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 endif()
 
 # We need to hide a ton of warnings
-include("${CMAKE_BINARY_DIR}/buildsystem/cmake-includes/silence-warnings/CMakeLists.txt")
+include("${CMAKE_SOURCE_DIR}/../cmake-includes/silence-warnings/CMakeLists.txt")
 
 # END Compiler config
 
@@ -245,3 +250,14 @@ target_link_libraries(
 )
 
 # END Linker config
+
+# BEGIN Test config
+
+add_test(
+    NAME engine_unit_tests
+    COMMAND $<TARGET_FILE:anura> --tests
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/../../
+)
+set_tests_properties(engine_unit_tests PROPERTIES LABELS "unittest")
+
+# END Test config

--- a/buildsystem/linux-dynamic/CMakePresets.json
+++ b/buildsystem/linux-dynamic/CMakePresets.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "configurePresets": [
+    {
+      "name": "default",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "FETCHCONTENT_QUIET": "FALSE"
+      }
+    },
+    {
+      "name": "Debug",
+      "inherits": [
+        "default"
+      ],
+      "binaryDir": "${sourceDir}/build/Debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "Release",
+      "inherits": [
+        "default"
+      ],
+      "binaryDir": "${sourceDir}/build/Release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    }
+  ]
+}

--- a/buildsystem/linux-steam/CMakeLists.txt
+++ b/buildsystem/linux-steam/CMakeLists.txt
@@ -2,7 +2,9 @@
 
 # 3.12 added add_compile_definitions
 # 3.14 added FetchContent
-cmake_minimum_required(VERSION 3.14)
+# 3.19 added presets v1: we use configurePresets
+# XXX - We cannot take this further than 3.23 as that's what ships in the Steam Sniper SDK!
+cmake_minimum_required(VERSION 3.19)
 
 if(DEFINED ENV{CXX})
   message("")
@@ -27,7 +29,7 @@ endif()
 # Prefer pkgconfig as that's what Conan will provide
 set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
-if(NOT EXISTS "${CMAKE_BINARY_DIR}/buildsystem/conan/conan_toolchain.cmake")
+if(NOT EXISTS "${CMAKE_SOURCE_DIR}/../conan/conan_toolchain.cmake")
     message("Conan toolchain file not found. ")
     message("")
     message(
@@ -37,7 +39,7 @@ if(NOT EXISTS "${CMAKE_BINARY_DIR}/buildsystem/conan/conan_toolchain.cmake")
 endif()
 
 # Use Conan as the package manager
-include(${CMAKE_BINARY_DIR}/buildsystem/conan/conan_toolchain.cmake)
+include(${CMAKE_SOURCE_DIR}/../conan/conan_toolchain.cmake)
 
 # END CMake setup
 
@@ -45,6 +47,9 @@ include(${CMAKE_BINARY_DIR}/buildsystem/conan/conan_toolchain.cmake)
 
 # Build target for CXX project "anura"
 project(anura LANGUAGES CXX)
+
+# For running tests through CTest
+enable_testing()
 
 # Build time dependencies
 find_package(Boost COMPONENTS filesystem REQUIRED)
@@ -65,7 +70,7 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/ocornut/imgui.git
     GIT_TAG d4ddc46e7773e9a9b68f965d007968f35ca4e09a # https://github.com/ocornut/imgui/releases/tag/v1.89.7
     GIT_SHALLOW TRUE
-    SOURCE_DIR "${CMAKE_BINARY_DIR}/src/imgui"
+    SOURCE_DIR "${CMAKE_SOURCE_DIR}/build/src/imgui"
     SOURCE_SUBDIR purposefully-empty-to-skip-build
 )
 
@@ -77,7 +82,7 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/g-truc/glm.git
     GIT_TAG 33b0eb9fa336ffd8551024b1d2690e418014553b # https://github.com/g-truc/glm/releases/tag/1.0.0
     GIT_SHALLOW TRUE
-    SOURCE_DIR "${CMAKE_BINARY_DIR}/src/glm"
+    SOURCE_DIR "${CMAKE_SOURCE_DIR}/build/src/glm"
     SOURCE_SUBDIR purposefully-empty-to-skip-build
 )
 
@@ -93,32 +98,32 @@ endif(CCACHE)
 file(
     GLOB
     anura_SRC
-    "${CMAKE_BINARY_DIR}/src/*.cpp"
-    "${CMAKE_BINARY_DIR}/src/hex/*.cpp"
-    "${CMAKE_BINARY_DIR}/src/imgui/imgui_draw.cpp"
-    "${CMAKE_BINARY_DIR}/src/imgui/imgui_tables.cpp"
-    "${CMAKE_BINARY_DIR}/src/imgui/imgui_widgets.cpp"
-    "${CMAKE_BINARY_DIR}/src/imgui/imgui.cpp"
-    "${CMAKE_BINARY_DIR}/src/imgui_additions/*.cpp"
-    "${CMAKE_BINARY_DIR}/src/kre/*.cpp"
-    "${CMAKE_BINARY_DIR}/src/svg/*.cpp"
-    "${CMAKE_BINARY_DIR}/src/tiled/*.cpp"
-    "${CMAKE_BINARY_DIR}/src/treetree/*.cpp"
-    "${CMAKE_BINARY_DIR}/src/xhtml/*.cpp"
+    "${CMAKE_SOURCE_DIR}/build/src/imgui/imgui_draw.cpp"
+    "${CMAKE_SOURCE_DIR}/build/src/imgui/imgui_tables.cpp"
+    "${CMAKE_SOURCE_DIR}/build/src/imgui/imgui_widgets.cpp"
+    "${CMAKE_SOURCE_DIR}/build/src/imgui/imgui.cpp"
+    "${CMAKE_SOURCE_DIR}/../../src/*.cpp"
+    "${CMAKE_SOURCE_DIR}/../../src/hex/*.cpp"
+    "${CMAKE_SOURCE_DIR}/../../src/imgui_additions/*.cpp"
+    "${CMAKE_SOURCE_DIR}/../../src/kre/*.cpp"
+    "${CMAKE_SOURCE_DIR}/../../src/svg/*.cpp"
+    "${CMAKE_SOURCE_DIR}/../../src/tiled/*.cpp"
+    "${CMAKE_SOURCE_DIR}/../../src/treetree/*.cpp"
+    "${CMAKE_SOURCE_DIR}/../../src/xhtml/*.cpp"
 )
 
 # Add the headers
 include_directories(
-    "${CMAKE_BINARY_DIR}/src"
-    "${CMAKE_BINARY_DIR}/src/glm"
-    "${CMAKE_BINARY_DIR}/src/hex"
-    "${CMAKE_BINARY_DIR}/src/imgui"
-    "${CMAKE_BINARY_DIR}/src/imgui_additions"
-    "${CMAKE_BINARY_DIR}/src/kre"
-    "${CMAKE_BINARY_DIR}/src/svg"
-    "${CMAKE_BINARY_DIR}/src/tiled"
-    "${CMAKE_BINARY_DIR}/src/treetree"
-    "${CMAKE_BINARY_DIR}/src/xhtml"
+    "${CMAKE_SOURCE_DIR}/build/src/glm"
+    "${CMAKE_SOURCE_DIR}/build/src/imgui"
+    "${CMAKE_SOURCE_DIR}/../../src"
+    "${CMAKE_SOURCE_DIR}/../../src/hex"
+    "${CMAKE_SOURCE_DIR}/../../src/imgui_additions"
+    "${CMAKE_SOURCE_DIR}/../../src/kre"
+    "${CMAKE_SOURCE_DIR}/../../src/svg"
+    "${CMAKE_SOURCE_DIR}/../../src/tiled"
+    "${CMAKE_SOURCE_DIR}/../../src/treetree"
+    "${CMAKE_SOURCE_DIR}/../../src/xhtml"
 )
 
 # END Project config
@@ -145,7 +150,7 @@ if (CMAKE_BUILD_TYPE MATCHES Release)
 endif()
 
 # Inject our own imgui config for our own vector operations
-add_compile_definitions(IMGUI_USER_CONFIG="${CMAKE_BINARY_DIR}/src/imgui_additions/imconfig_anura.h")
+add_compile_definitions(IMGUI_USER_CONFIG="${CMAKE_SOURCE_DIR}/../../src/imgui_additions/imconfig_anura.h")
 
 if (CMAKE_BUILD_TYPE MATCHES Release)
     # Turn all things debug, like assertions, off for a release build
@@ -165,7 +170,7 @@ add_compile_definitions(GLM_ENABLE_EXPERIMENTAL)
 # XXX - The md5 module of anura does not build without this.
 # XXX - Other files also emit the warning, but somehow this gets elevated to an error - no clue, probably worse.
 set_property(
-    SOURCE "${CMAKE_BINARY_DIR}/src/md5.cpp"
+    SOURCE "${CMAKE_SOURCE_DIR}/../../src/md5.cpp"
     APPEND_STRING
     PROPERTY COMPILE_FLAGS " -Wno-narrowing"
 )
@@ -201,3 +206,14 @@ target_link_libraries(
 )
 
 # END Linker config
+
+# BEGIN Test config
+
+add_test(
+    NAME engine_unit_tests
+    COMMAND $<TARGET_FILE:anura> --tests
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/../../
+)
+set_tests_properties(engine_unit_tests PROPERTIES LABELS "unittest")
+
+# END Test config

--- a/buildsystem/linux-steam/CMakePresets.json
+++ b/buildsystem/linux-steam/CMakePresets.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "configurePresets": [
+    {
+      "name": "default",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "FETCHCONTENT_QUIET": "FALSE"
+      }
+    },
+    {
+      "name": "Debug",
+      "inherits": [
+        "default"
+      ],
+      "binaryDir": "${sourceDir}/build/Debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "Release",
+      "inherits": [
+        "default"
+      ],
+      "binaryDir": "${sourceDir}/build/Release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
* Lean on configuration presets for ergonomics
* Drop Debian Bullseye as its CMake is too old to support configuration presets
* Relativize everything to `${CMAKE_SOURCE_DIR}` instead of `${CMAKE_BINARY_DIR}` as intended by upstream
* Isolate all transient outputs to a build dir in the `buildsystem` subtree
* Isolate all outputs to a build dir in the `buildsystem` subtree
* Switch to wrapping the build with `cmake`
  * Improved ergonomics for handling the transient `Makefile` being generated in a deep in the `buildsystem/` subtree
  * Future proofing for CMake 4 switching the default build tool from `make` to `ninja`
* Switch to wrapping the unit tests with `ctest`