### PR TITLE
Only write ccache caches on pushes to trunk

### DIFF
--- a/.github/workflows/pr-smoketest-alma.yaml
+++ b/.github/workflows/pr-smoketest-alma.yaml
@@ -1,6 +1,9 @@
 name: Smoketest / Informative / Alma
 on:
   pull_request:
+  push:
+    branches:
+      - trunk
 
 jobs:
   test:
@@ -56,10 +59,12 @@ jobs:
       - name: Checkout Anura
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      # Only write to cache on pushes to trunk
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@bfa03e1de4d7f7c3e80ad9109feedd05c4f5a716 # v1.2.19
         with:
           key: ${{ github.job }}-alma-${{ matrix.alma }}-${{ matrix.compiler }}-${{ matrix.build-type }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-smoketest-debian.yaml
+++ b/.github/workflows/pr-smoketest-debian.yaml
@@ -1,6 +1,9 @@
 name: Smoketest / Informative / Debian
 on:
   pull_request:
+  push:
+    branches:
+      - trunk
 
 jobs:
   test:
@@ -57,10 +60,12 @@ jobs:
       - name: Checkout Anura
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      # Only write to cache on pushes to trunk
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@bfa03e1de4d7f7c3e80ad9109feedd05c4f5a716 # v1.2.19
         with:
           key: ${{ github.job }}-debian-${{ matrix.debian }}-${{ matrix.compiler }}-${{ matrix.build-type }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-smoketest-fedora.yaml
+++ b/.github/workflows/pr-smoketest-fedora.yaml
@@ -1,6 +1,9 @@
 name: Smoketest / Informative / Fedora
 on:
   pull_request:
+  push:
+    branches:
+      - trunk
 
 jobs:
   test:
@@ -53,10 +56,12 @@ jobs:
       - name: Checkout Anura
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      # Only write to cache on pushes to trunk
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@bfa03e1de4d7f7c3e80ad9109feedd05c4f5a716 # v1.2.19
         with:
           key: ${{ github.job }}-fedora-${{ matrix.fedora }}-${{ matrix.compiler }}-${{ matrix.build-type }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-smoketest-opensuse-leap.yaml
+++ b/.github/workflows/pr-smoketest-opensuse-leap.yaml
@@ -1,6 +1,9 @@
 name: Smoketest / Informative / openSUSE Leap
 on:
   pull_request:
+  push:
+    branches:
+      - trunk
 
 jobs:
   test:
@@ -55,10 +58,12 @@ jobs:
       - name: Checkout Anura
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      # Only write to cache on pushes to trunk
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@bfa03e1de4d7f7c3e80ad9109feedd05c4f5a716 # v1.2.19
         with:
           key: ${{ github.job }}-opensuse-leap-${{ matrix.suse }}-${{ matrix.compiler }}-${{ matrix.build-type }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-smoketest-rocky.yaml
+++ b/.github/workflows/pr-smoketest-rocky.yaml
@@ -1,6 +1,9 @@
 name: Smoketest / Informative / Rocky
 on:
   pull_request:
+  push:
+    branches:
+      - trunk
 
 jobs:
   test:
@@ -56,10 +59,12 @@ jobs:
       - name: Checkout Anura
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      # Only write to cache on pushes to trunk
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@bfa03e1de4d7f7c3e80ad9109feedd05c4f5a716 # v1.2.19
         with:
           key: ${{ github.job }}-rocky-${{ matrix.rocky }}-${{ matrix.compiler }}-${{ matrix.build-type }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-smoketest-ubuntu.yaml
+++ b/.github/workflows/pr-smoketest-ubuntu.yaml
@@ -1,6 +1,9 @@
 name: Smoketest / Informative / Ubuntu
 on:
   pull_request:
+  push:
+    branches:
+      - trunk
 
 jobs:
   test:
@@ -58,10 +61,12 @@ jobs:
       - name: Checkout Anura
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      # Only write to cache on pushes to trunk
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@bfa03e1de4d7f7c3e80ad9109feedd05c4f5a716 # v1.2.19
         with:
           key: ${{ github.job }}-ubuntu-${{ matrix.ubuntu }}-${{ matrix.compiler }}-${{ matrix.build-type }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-unit-tests-dynamic-linux.yaml
+++ b/.github/workflows/pr-unit-tests-dynamic-linux.yaml
@@ -2,6 +2,9 @@ name: Unit Tests / Required / Dynamic / Linux
 on:
   pull_request:
   merge_group:
+  push:
+    branches:
+      - trunk
 
 jobs:
   test:
@@ -43,10 +46,12 @@ jobs:
       - name: Checkout Anura
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      # Only write to cache on pushes to trunk
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@bfa03e1de4d7f7c3e80ad9109feedd05c4f5a716 # v1.2.19
         with:
           key: unit-tests-linux-${{ matrix.build-type }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-unit-tests-static-linux.yaml
+++ b/.github/workflows/pr-unit-tests-static-linux.yaml
@@ -2,6 +2,9 @@ name: Unit Tests / Required / Static / Linux
 on:
   pull_request:
   merge_group:
+  push:
+    branches:
+      - trunk
 
 jobs:
   build:
@@ -45,10 +48,12 @@ jobs:
       - name: Ignore Filesystem Permissions for Git
         run: git config --global --add safe.directory '*'
 
+      # Only write to cache on pushes to trunk
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@bfa03e1de4d7f7c3e80ad9109feedd05c4f5a716 # v1.2.19
         with:
           key: unit-tests-linux-static-steam-${{ matrix.build-type }}-${{ matrix.compiler }}-${{ matrix.steam-runtime }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/trunk' }}
 
       - name: Install Conan
         uses: conan-io/setup-conan@09566912d661de90608308897a4d513e850c04e8 # v1.2.0


### PR DESCRIPTION
GitHub will start charging for cache volume mid October 2025.