### PR TITLE
CI: also cache on Sundays

### DIFF
--- a/.github/workflows/pr-smoketest-alma.yaml
+++ b/.github/workflows/pr-smoketest-alma.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - trunk
+  schedule:
+    - cron: '0 0 * * 0' # Weekly on Sunday
 
 jobs:
   test:
@@ -64,7 +66,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@bfa03e1de4d7f7c3e80ad9109feedd05c4f5a716 # v1.2.19
         with:
           key: ${{ github.job }}-alma-${{ matrix.alma }}-${{ matrix.compiler }}-${{ matrix.build-type }}
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/trunk' }}
+          save: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-smoketest-debian.yaml
+++ b/.github/workflows/pr-smoketest-debian.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - trunk
+  schedule:
+    - cron: '0 0 * * 0' # Weekly on Sunday
 
 jobs:
   test:
@@ -65,7 +67,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@bfa03e1de4d7f7c3e80ad9109feedd05c4f5a716 # v1.2.19
         with:
           key: ${{ github.job }}-debian-${{ matrix.debian }}-${{ matrix.compiler }}-${{ matrix.build-type }}
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/trunk' }}
+          save: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-smoketest-fedora.yaml
+++ b/.github/workflows/pr-smoketest-fedora.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - trunk
+  schedule:
+    - cron: '0 0 * * 0' # Weekly on Sunday
 
 jobs:
   test:
@@ -61,7 +63,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@bfa03e1de4d7f7c3e80ad9109feedd05c4f5a716 # v1.2.19
         with:
           key: ${{ github.job }}-fedora-${{ matrix.fedora }}-${{ matrix.compiler }}-${{ matrix.build-type }}
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/trunk' }}
+          save: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-smoketest-opensuse-leap.yaml
+++ b/.github/workflows/pr-smoketest-opensuse-leap.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - trunk
+  schedule:
+    - cron: '0 0 * * 0' # Weekly on Sunday
 
 jobs:
   test:
@@ -58,12 +60,12 @@ jobs:
       - name: Checkout Anura
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      # Only write to cache on pushes to trunk
+      # Only write to cache on pushes to trunk and scheduled builds on trunk
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@bfa03e1de4d7f7c3e80ad9109feedd05c4f5a716 # v1.2.19
         with:
           key: ${{ github.job }}-opensuse-leap-${{ matrix.suse }}-${{ matrix.compiler }}-${{ matrix.build-type }}
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/trunk' }}
+          save: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-smoketest-rocky.yaml
+++ b/.github/workflows/pr-smoketest-rocky.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - trunk
+  schedule:
+    - cron: '0 0 * * 0' # Weekly on Sunday
 
 jobs:
   test:
@@ -64,7 +66,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@bfa03e1de4d7f7c3e80ad9109feedd05c4f5a716 # v1.2.19
         with:
           key: ${{ github.job }}-rocky-${{ matrix.rocky }}-${{ matrix.compiler }}-${{ matrix.build-type }}
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/trunk' }}
+          save: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-smoketest-ubuntu.yaml
+++ b/.github/workflows/pr-smoketest-ubuntu.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - trunk
+  schedule:
+    - cron: '0 0 * * 0' # Weekly on Sunday
 
 jobs:
   test:
@@ -66,7 +68,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@bfa03e1de4d7f7c3e80ad9109feedd05c4f5a716 # v1.2.19
         with:
           key: ${{ github.job }}-ubuntu-${{ matrix.ubuntu }}-${{ matrix.compiler }}-${{ matrix.build-type }}
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/trunk' }}
+          save: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-unit-tests-dynamic-linux.yaml
+++ b/.github/workflows/pr-unit-tests-dynamic-linux.yaml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - trunk
+  schedule:
+    - cron: '0 0 * * 0' # Weekly on Sunday
 
 jobs:
   test:
@@ -51,7 +53,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@bfa03e1de4d7f7c3e80ad9109feedd05c4f5a716 # v1.2.19
         with:
           key: unit-tests-linux-${{ matrix.build-type }}
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/trunk' }}
+          save: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-unit-tests-static-linux.yaml
+++ b/.github/workflows/pr-unit-tests-static-linux.yaml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - trunk
+  schedule:
+    - cron: '0 0 * * 0' # Weekly on Sunday
 
 jobs:
   build:
@@ -53,7 +55,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@bfa03e1de4d7f7c3e80ad9109feedd05c4f5a716 # v1.2.19
         with:
           key: unit-tests-linux-static-steam-${{ matrix.build-type }}-${{ matrix.compiler }}-${{ matrix.steam-runtime }}
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/trunk' }}
+          save: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/trunk' }}
 
       - name: Install Conan
         uses: conan-io/setup-conan@09566912d661de90608308897a4d513e850c04e8 # v1.2.0

--- a/README.md
+++ b/README.md
@@ -401,6 +401,29 @@ On Pull Requests:
 * NOT IMPLEMENTED [LLVM
   scan-build](https://clang-analyzer.llvm.org/scan-build.html)
 
+### Caching
+
+In October 2025 GitHub got stricter about how its free caching tier works. We
+now get 7d lifetime on the caches created instead of the previously
+undocumented-but-sorta-inferrable 30d. We will also get a 10GB hard limit where
+new entries evict the oldest entries on creation where previously we simply had
+a warning about having exceeded the free 10GB limit.
+
+The previous caching strategy (before 2025-09) simply wrote to the cache from
+all builds, leading into situations where we could be consuming 100s of GBs of
+cache. Which we deemed fine as it only resulted in a soft warning and no extra
+costs.
+
+The current (2025-10) hot set of ccache stored objects for all the build
+permutations of Anura is about 13GB. This means we will get build acceleration
+happening for free for up to 10GB, which is ok enough for at least quartering
+the compute we spend on a per push basis.
+
+The resulting caching strategy going forwards:
+
+* Cache on all pushes to the default branch `trunk` to refresh new objects
+* Cache on Sundays to ensure we have some hot 10GB set within the 7d limit
+
 ## CD
 
 All publishing will happen from the module side, most notably from


### PR DESCRIPTION
As the new eviction policy kicking in mid-October is 10GB or 7d, make sure we'll always have 10GB of something useful cached up at all times by also scheduling the cache filling builds to happen on every Sunday.