### PR TITLE
Pin libwebp to 1.5.0 for the Steam builds

### DIFF
--- a/buildsystem/conan/conanfile.py
+++ b/buildsystem/conan/conanfile.py
@@ -11,12 +11,13 @@ class Anura(ConanFile):
         "build_type",
     ]
 
-    # Anything we actually link against is explicitly pinned
+    # Minimal organically growing set to keep the Steam build alive
     requires = [
         "boost/1.88.0",
         "cairo/1.18.0",
         "freetype/2.13.2",
         "glew/2.2.0",
+        "libwebp/1.5.0", # 1.6.0 wants -mavx2 which breaks builds on SteamOS
         "sdl_image/2.8.2",
         "sdl_ttf/2.24.0",
         "sdl/2.28.3",


### PR DESCRIPTION
Steam builds seem broken since upstream rolled this out: https://github.com/conan-io/conan-center-index/commit/a6bb00486f2ce1813b96324fa8088afc7e653f4c

Seems this is slowly turning into a traditional "everything should be pinned" issue over time. Not that bad to catch things like once per quarter or so.

Will later look into how to properly pin the full set of dependencies for the Steam builds.