### PR TITLE
Exclude Alma 9 with clang from the build matrix

### DIFF
--- a/.github/workflows/pr-smoketest-alma.yaml
+++ b/.github/workflows/pr-smoketest-alma.yaml
@@ -14,19 +14,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        alma:
+        include:
           # 8 is the oldest Alma Linux to exist
-          - "8"
-          - "9"
+          - alma: "8"
+            compiler: g++
+            build-type: Debug
+          - alma: "8"
+            compiler: g++
+            build-type: Release
+          - alma: "8"
+            compiler: clang++
+            build-type: Debug
+          - alma: "8"
+            compiler: clang++
+            build-type: Release
+          # Alma 9 ships Clang 20 and that cannot build against Boost MPL older than 1.86, and Alma 9 ships 1.75
+          - alma: "9"
+            compiler: g++
+            build-type: Debug
+          - alma: "9"
+            compiler: g++
+            build-type: Release
           # 10 is expected in 2025-05
           # 11 is expected in 2028-05
           # 12 is expected in 2031-05
-        compiler:
-          - g++
-          - clang++
-        build-type:
-          - Release
-          - Debug
     container: almalinux:${{ matrix.alma }}
     steps:
       - name: Install Dependencies


### PR DESCRIPTION
Alma 9 ships Clang 20 and that cannot build against Boost MPL older than 1.86, and Alma 9 ships 1.75.

https://wiki.almalinux.org/release-notes/9.7.html

See upstream: https://github.com/llvm/llvm-project/issues/104850