### PR TITLE
Stage 1 of input remapping

### DIFF
--- a/data/controls.cfg
+++ b/data/controls.cfg
@@ -1,5 +1,15 @@
 {
 	"controls": {
+		"names": {
+			"left": ~Left~,
+			"right": ~Right~,
+			"up": ~Up~,
+			"down": ~Down~,
+			"confirm": ~Confirm~,
+			"menu": ~Menu~,
+			"pause": ~Pause~,
+			"cancel": ~Cancel~,
+		},
 		"key_bindings": {
 			# left/right/up/down and confirm/menu/pause/cancel should be defined at engine level as they are used for ui
 			# defining specific keys for confirm/cancel will help with trying to screenshot dialogue, as it will

--- a/data/controls.cfg
+++ b/data/controls.cfg
@@ -1,0 +1,59 @@
+{
+	"controls": {
+		"key_bindings": {
+			# left/right/up/down and confirm/menu/pause/cancel should be defined at engine level as they are used for ui
+			# defining specific keys for confirm/cancel will help with trying to screenshot dialogue, as it will
+			# not go forward to new dialogue because I pressed Mod4+PrintScreen
+			#
+			# when re-binding we must also check that each 'action' has at least one input assigned to it
+			"left": [ ["Left"] ],
+			"right": [ ["Right"] ],
+			"up": [ ["Up"] ],
+			"down": [ ["Down"] ],
+			"confirm": [
+				["A"],
+				["Space"],
+				["Return"],
+				["Keypad Enter"],
+			],
+			"menu": [ ["Escape"] ],
+			"pause": [
+				["Left Ctrl", "P"],
+				["Right Ctrl", "P"],
+			],
+			"cancel": [
+				["S"],
+				["Escape"],
+			],
+		},
+		"button_bindings": {
+			"left": [
+				["SDL_CONTROLLER_BUTTON_DPAD_LEFT"],
+			],
+			"right": [
+				["SDL_CONTROLLER_BUTTON_DPAD_RIGHT"],
+			],
+			"up": [
+				["SDL_CONTROLLER_BUTTON_DPAD_UP"],
+			],
+			"down": [
+				["SDL_CONTROLLER_BUTTON_DPAD_DOWN"],
+			],
+			"confirm": [
+				["SDL_CONTROLLER_BUTTON_A"], # where abxy = bottom right left top
+			],
+			"menu": [
+				["SDL_CONTROLLER_BUTTON_START"], # the left of the two center ones
+			],
+			"cancel": [
+				["SDL_CONTROLLER_BUTTON_B"],
+			],
+		},
+		"axes_bindings": {
+			SDL_CONTROLLER_AXIS_LEFTX: ["left","right"],
+			SDL_CONTROLLER_AXIS_LEFTY: ["up", "down"],
+			SDL_CONTROLLER_AXIS_RIGHTX: ["look_left","look_right"],
+			SDL_CONTROLLER_AXIS_RIGHTY: ["look_up","look_down"]
+		}
+	}
+}

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -140,37 +140,6 @@ namespace controls
 		}
 		return variant::from_bool(false);
 	}
-	void apply_engine_controls(variant node)
-	{
-	    std::map<variant, variant> key_binds = node["controls"]["key_bindings"].as_map();
-	    for(auto p = key_binds.begin(); p != key_binds.end(); ++p) {
-	        std::string action_name = p->first.as_string();
-			ComboList combo_list;
-
-			printf("Action %s\n", action_name.c_str());
-
-			std::vector<variant> key_sequences = p->second.as_list();
-	        for(int i=0;i<key_sequences.size();i++){
-				std::vector<std::string> key_combo = key_sequences[i].as_list_string();
-				KeyCombination kb;
-
-	            printf("Key combo: ");
-				for(int j=0;j<key_combo.size();j++){
-					const char* key_name = key_combo[j].c_str();
-					printf("%s\n", key_name);
-					int keycode = SDL_GetKeyFromName(key_name);
-					//TODO: Handle 'unknown' key
-					if(keycode != SDLK_UNKNOWN){
-						kb.push_back(keycode);
-					}
-				}
-				combo_list.push_back(kb);
-	            printf("\n"); // print a new line after each key combination
-			}
-
-			engine_keys.insert({action_name, combo_list});
-	    }
-	}
 
 	const char** control_names()
 	{

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -82,12 +82,6 @@ namespace controls
 	    }
 	}
 
-	const char** control_names()
-	{
-		static const char* names[] = { "up", "down", "left", "right", "attack", "jump", "tongue", "sprint", nullptr };
-		return names;
-	}
-
 	variant get_keys_for_action(std::string action_name, KeyBindings &keys){
 		std::vector<variant> result = {};
 

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -39,6 +39,7 @@
 
 #include "asserts.hpp"
 #include "controls.hpp"
+#include "module.hpp"
 #include "joystick.hpp"
 #include "multiplayer.hpp"
 #include "preferences.hpp"
@@ -50,7 +51,7 @@ namespace controls
 {
 	std::map<std::string, ComboList> engine_keys;
 
-	void parse_controls_from_node_into_map(variant node, std::map<std::string, ComboList> dictionary){
+	void parse_keys_from_node_into_map(variant node, std::map<std::string, ComboList> *dictionary){
 	    std::map<variant, variant> key_binds = node.as_map();
 	    for(auto p = key_binds.begin(); p != key_binds.end(); ++p) {
 	        std::string action_name = p->first.as_string();
@@ -76,8 +77,8 @@ namespace controls
 				combo_list.push_back(kb);
 	            printf("\n"); // print a new line after each key combination
 			}
-
-			dictionary.insert({action_name, combo_list});
+			printf("Inserting key value pair %s %d\n", action_name.c_str(), combo_list[0][0]);
+			dictionary->insert({action_name, combo_list});
 	    }
 	}
 
@@ -87,7 +88,7 @@ namespace controls
 		return names;
 	}
 
-	variant get_keys_for_action(std::string action_name){
+	variant get_engine_keys_for_action(std::string action_name){
 		std::vector<variant> result = {};
 
 		if (engine_keys.find(action_name) != engine_keys.end()) {
@@ -107,7 +108,28 @@ namespace controls
 		return variant(&result);
 	};
 
-	variant set_key_for_action(std::string action_name, int index, std::vector<int> value){
+	variant get_module_keys_for_action(std::string action_name){
+		std::vector<variant> result = {};
+		std::map<std::string, ComboList> module_keys = module::get_module_keys();
+
+		if (module_keys.find(action_name) != module_keys.end()) {
+	        printf("Action %s found.\n", action_name.c_str());
+			ComboList events = module_keys[action_name];
+			for(int i=0;i<events.size();i++){
+				KeyCombination kb;
+				kb = events[i];
+				std::vector<variant> tmp = {};
+				for(int j=0;j<kb.size();j++){
+					tmp.push_back(variant(kb[j]));
+				}
+				result.emplace_back(variant(&tmp));
+			}
+	    }
+
+		return variant(&result);
+	};
+
+	variant set_engine_key_for_action(std::string action_name, int index, std::vector<int> value){
 		if (engine_keys.find(action_name) != engine_keys.end()) {
 			ComboList events = engine_keys[action_name];
 			if(index >= events.size()){

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -50,6 +50,43 @@ namespace controls
 {
 	std::map<std::string, ComboList> engine_keys;
 
+	void parse_controls_from_node_into_map(variant node, std::map<std::string, ComboList> dictionary){
+	    std::map<variant, variant> key_binds = node.as_map();
+	    for(auto p = key_binds.begin(); p != key_binds.end(); ++p) {
+	        std::string action_name = p->first.as_string();
+			ComboList combo_list;
+
+			printf("Action %s\n", action_name.c_str());
+
+			std::vector<variant> key_sequences = p->second.as_list();
+	        for(int i=0;i<key_sequences.size();i++){
+				std::vector<std::string> key_combo = key_sequences[i].as_list_string();
+				KeyCombination kb;
+
+	            printf("Key combo: ");
+				for(int j=0;j<key_combo.size();j++){
+					const char* key_name = key_combo[j].c_str();
+					printf("%s\n", key_name);
+					int keycode = SDL_GetKeyFromName(key_name);
+					//TODO: Handle 'unknown' key
+					if(keycode != SDLK_UNKNOWN){
+						kb.push_back(keycode);
+					}
+				}
+				combo_list.push_back(kb);
+	            printf("\n"); // print a new line after each key combination
+			}
+
+			dictionary.insert({action_name, combo_list});
+	    }
+	}
+
+	const char** control_names()
+	{
+		static const char* names[] = { "up", "down", "left", "right", "attack", "jump", "tongue", "sprint", nullptr };
+		return names;
+	}
+
 	variant get_keys_for_action(std::string action_name){
 		std::vector<variant> result = {};
 

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -21,6 +21,7 @@
 	   distribution.
 */
 
+#include "variant_type.hpp"
 #include <SDL2/SDL_keycode.h>
 #ifdef _MSC_VER
 #include <winsock2.h>
@@ -48,6 +49,26 @@ PREF_INT(max_control_history, 1024, "Maximum number of frames to keep control hi
 namespace controls
 {
 	std::map<std::string, ComboList> engine_keys;
+
+	variant get_keys_for_action(std::string action_name){
+		std::vector<variant> result = {};
+
+		if (engine_keys.find(action_name) != engine_keys.end()) {
+	        printf("Action %s found.\n", action_name.c_str());
+			ComboList events = engine_keys[action_name];
+			for(int i=0;i<events.size();i++){
+				KeyCombination kb;
+				kb = events[i];
+				std::vector<variant> tmp = {};
+				for(int j=0;j<kb.size();j++){
+					tmp.push_back(variant(kb[j]));
+				}
+				result.emplace_back(variant(&tmp));
+			}
+	    }
+
+		return variant(&result);
+	};
 
 	void apply_engine_controls(variant node)
 	{

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -49,34 +49,35 @@ PREF_INT(max_control_history, 1024, "Maximum number of frames to keep control hi
 
 namespace controls
 {
-	KeyBindings engine_keys;
-	std::map<std::string, bool> dirty_actions; //To store if a user has changed an action's binds from the default
-	std::map<std::string, std::string> action_names;
-
-	void parse_action_names(variant node){
+	ActionBindings::ActionBindings(){
+	}
+	ActionBindings::~ActionBindings(){
+		//TODO: Is there anything I need to free here?
+	}
+	void ActionBindings::parse_action_names(variant node){
 		std::map<variant, variant> acts = node.as_map();
 
 		for(auto p = acts.begin(); p!=acts.end();++p){
 			std::string act_id = p->first.as_string();
 			std::string act_name = p->second.as_string();
-			action_names.insert({act_id, act_name});
+			this->action_names.insert({act_id, act_name});
 		}
-	}
+	};
 
-	void parse_keys_from_node_into_map(variant node, std::map<std::string, ComboList> *dictionary){
-	    std::map<variant, variant> key_binds = node.as_map();
-	    for(auto p = key_binds.begin(); p != key_binds.end(); ++p) {
-	        std::string action_name = p->first.as_string();
+	void ActionBindings::parse_keys(variant node){
+		std::map<variant, variant> key_binds = node.as_map();
+		for(auto p = key_binds.begin(); p != key_binds.end(); ++p) {
+		    std::string action_name = p->first.as_string();
 			ComboList combo_list;
 
 			printf("Action %s\n", action_name.c_str());
 
 			std::vector<variant> key_sequences = p->second.as_list();
-	        for(int i=0;i<key_sequences.size();i++){
+			for(int i=0;i<key_sequences.size();i++){
 				std::vector<std::string> key_combo = key_sequences[i].as_list_string();
 				KeyCombination kb;
 
-	            printf("Key combo: ");
+			    printf("Key combo: ");
 				for(int j=0;j<key_combo.size();j++){
 					const char* key_name = key_combo[j].c_str();
 					printf("%s\n", key_name);
@@ -87,19 +88,19 @@ namespace controls
 					}
 				}
 				combo_list.push_back(kb);
-	            printf("\n"); // print a new line after each key combination
+			    printf("\n"); // print a new line after each key combination
 			}
 			printf("Inserting key value pair %s %d\n", action_name.c_str(), combo_list[0][0]);
-			dictionary->insert({action_name, combo_list});
-	    }
-	}
+			this->key_mapping.insert({action_name, combo_list});
+		}
+	};
 
-	variant get_keys_for_action(std::string action_name, KeyBindings &keys){
+	variant ActionBindings::get_keys_for_action(std::string action_name){
 		std::vector<variant> result = {};
 
-		if (keys.find(action_name) != keys.end()) {
+		if (this->key_mapping.find(action_name) != this->key_mapping.end()) {
 	        printf("Action %s found.\n", action_name.c_str());
-			ComboList events = keys[action_name];
+			ComboList events = this->key_mapping[action_name];
 			for(int i=0;i<events.size();i++){
 				KeyCombination kb;
 				kb = events[i];
@@ -112,11 +113,11 @@ namespace controls
 	    }
 
 		return variant(&result);
-	};
+	}
 
-	variant add_key_for_action(std::string action_name, int before_index, KeyCombination value, KeyBindings &keys){
-		if (keys.find(action_name) != keys.end()) {
-			ComboList events = keys[action_name];
+	variant ActionBindings::add_key_for_action(std::string action_name, int before_index, KeyCombination value){
+		if (this->key_mapping.find(action_name) != this->key_mapping.end()) {
+			ComboList events = this->key_mapping[action_name];
 
 			KeyCombination k;
 			for(int i=0;i<value.size();i++){
@@ -124,23 +125,23 @@ namespace controls
 			}
 
 			std::vector<int> temp = k;
-			if(before_index >= events.size()){
+			if(before_index >= events.size() && before_index != 0){
 				// List index out of range
 				return variant::from_bool(false);
 			}
 			events.insert(events.begin() + before_index, temp);
-			keys[action_name] = events;
+			this->key_mapping[action_name] = events;
 
 			// Assign back the modified array
-			dirty_actions[action_name] = true;
+			this->dirty_actions[action_name] = true;
 			return variant::from_bool(true);
 		}
 		return variant::from_bool(false);
 	}
 
-	variant del_key_for_action(std::string action_name, int at_index, KeyBindings &keys){
-		if (keys.find(action_name) != keys.end()) {
-			ComboList events = keys[action_name];
+	variant ActionBindings::del_key_for_action(std::string action_name, int at_index){
+		if (this->key_mapping.find(action_name) != this->key_mapping.end()) {
+			ComboList events = this->key_mapping[action_name];
 
 			if(at_index >= events.size()){
 				// List index out of range
@@ -151,45 +152,90 @@ namespace controls
 			events.erase(events.begin() + at_index);
 
 			// Assign back the modified array
-			keys[action_name] = events;
+			this->key_mapping[action_name] = events;
 
-			dirty_actions[action_name] = true;
+			this->dirty_actions[action_name] = true;
 			return variant::from_bool(true);
 		}
 		return variant::from_bool(false);
 	}
 
-	std::map<std::string, std::string> get_action_names(){
+	std::map<std::string, std::string> ActionBindings::get_action_names(){
 		return action_names;
 	}
 
-	void set_keys_for_action(std::string action, ComboList &combos){
-		engine_keys[action] = combos;
+	void ActionBindings::set_keys_for_action(std::string action, ComboList &combos){
+		this->key_mapping[action] = combos;
 	}
 
-	bool has_action(std::string action_name, KeyBindings &keys){
-		if(keys.find(action_name) == keys.end()){
+	bool ActionBindings::has_action(std::string action_name){
+		if(this->key_mapping.find(action_name) == this->key_mapping.end()){
 			return false;
 		}
 		return true;
 	}
-	void set_are_bindings_default(std::string action_name, bool value){
+	void ActionBindings::set_are_bindings_default(std::string action_name, bool value){
 		if(value == false){
-			dirty_actions[action_name] = true;
+			this->dirty_actions[action_name] = true;
 		} else {
-			auto itor = dirty_actions.find(action_name);
-			if (itor != dirty_actions.end()){
-				dirty_actions.erase(itor);
+			auto itor = this->dirty_actions.find(action_name);
+			if (itor != this->dirty_actions.end()){
+				this->dirty_actions.erase(itor);
 			}
 		}
 	}
 
-	bool are_bindings_default_for_action(std::string action_name){
-		if (dirty_actions.find(action_name) == dirty_actions.end()) {
+	bool ActionBindings::are_bindings_default_for_action(std::string action_name){
+		if (this->dirty_actions.find(action_name) == this->dirty_actions.end()) {
 			return true;
 		}
 		return false;
 	}
+
+	void ActionBindings::write_to_preferences(variant_builder *node){
+		for(auto p = this->action_names.begin(); p != this->action_names.end(); ++p) {
+      		std::string action_name = p->first;
+        	if(this->are_bindings_default_for_action(action_name)){
+         		printf("Not writing keys for %s, as is has not been changed by user\n", action_name.c_str());
+         		continue;
+         	}
+        	std::string preference_name = "keys_";
+        	preference_name += action_name;
+
+         	node->add(preference_name, this->get_keys_for_action(action_name));
+		}
+	}
+
+	void ActionBindings::read_from_preferences(variant node){
+		for(auto p = action_names.begin(); p != action_names.end(); ++p) {
+      		std::string action_name = p->first;
+        	std::string preference_name = "keys_";
+        	preference_name += action_name;
+
+         	// For each 'keys_action' that is found in preferences.cfg
+        	const variant keys_node = node[preference_name];
+         	if(keys_node.is_null() == false) {
+          		printf("Found preference key %s\n", preference_name.c_str());
+          		// Mark action as dirty, i.e. changed from default
+          		this->set_are_bindings_default(action_name, false);
+
+            	// Parse the data (key combinations) from variants
+             	// to the KeyCombination type.
+            	controls::ComboList combos;
+            	std::vector<variant> temp = keys_node.as_list();
+             	for(int i=0;i<temp.size();i++){
+              		controls::KeyCombination key_combo;
+               		key_combo = temp[i].as_list_int();
+            		combos.push_back(key_combo);
+              	}
+
+              	// Assign the new bindings
+              	this->set_keys_for_action(action_name, combos);
+			}
+		}
+	}
+
+	ActionBindings engine_mappings;
 
 	const char** control_names()
 	{

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -88,12 +88,12 @@ namespace controls
 		return names;
 	}
 
-	variant get_engine_keys_for_action(std::string action_name){
+	variant get_keys_for_action(std::string action_name, KeyBindings &keys){
 		std::vector<variant> result = {};
 
-		if (engine_keys.find(action_name) != engine_keys.end()) {
+		if (keys.find(action_name) != keys.end()) {
 	        printf("Action %s found.\n", action_name.c_str());
-			ComboList events = engine_keys[action_name];
+			ComboList events = keys[action_name];
 			for(int i=0;i<events.size();i++){
 				KeyCombination kb;
 				kb = events[i];
@@ -108,44 +108,37 @@ namespace controls
 		return variant(&result);
 	};
 
-	variant get_module_keys_for_action(std::string action_name){
-		std::vector<variant> result = {};
-		std::map<std::string, ComboList> module_keys = module::get_module_keys();
+	variant add_key_for_action(std::string action_name, int before_index, KeyCombination value, KeyBindings &keys){
+		if (keys.find(action_name) != keys.end()) {
+			ComboList events = keys[action_name];
 
-		if (module_keys.find(action_name) != module_keys.end()) {
-	        printf("Action %s found.\n", action_name.c_str());
-			ComboList events = module_keys[action_name];
-			for(int i=0;i<events.size();i++){
-				KeyCombination kb;
-				kb = events[i];
-				std::vector<variant> tmp = {};
-				for(int j=0;j<kb.size();j++){
-					tmp.push_back(variant(kb[j]));
-				}
-				result.emplace_back(variant(&tmp));
-			}
-	    }
-
-		return variant(&result);
-	};
-
-	variant set_engine_key_for_action(std::string action_name, int index, std::vector<int> value){
-		if (engine_keys.find(action_name) != engine_keys.end()) {
-			ComboList events = engine_keys[action_name];
-			if(index >= events.size()){
-				// List index out of range
-				return variant(0);
-			}
-
-			KeyCombination k = events[index];
-			k.clear();
+			KeyCombination k;
 			for(int i=0;i<value.size();i++){
 				k.push_back(value[i]);
 			}
-			engine_keys[action_name][index] = k;
-			return variant(1);
+
+			std::vector<int> temp = k;
+			events.insert(events.begin() + before_index, temp);
+			keys[action_name] = events;
+			return variant::from_bool(true);
 		}
-		return variant(0);
+		return variant::from_bool(false);
+	}
+
+	variant del_key_for_action(std::string action_name, int at_index, KeyBindings &keys){
+		if (keys.find(action_name) != keys.end()) {
+			ComboList events = keys[action_name];
+
+			if(at_index >= events.size()){
+				// List index out of range
+				return variant::from_bool(false);
+			}
+			//TODO: Determine if the allocated memory for the KeyCombo at events[at_index] will be
+			// automatically freed
+			events.erase(events.begin() + at_index);
+			return variant::from_bool(true);
+		}
+		return variant::from_bool(false);
 	}
 	void apply_engine_controls(variant node)
 	{

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -49,8 +49,10 @@ PREF_INT(max_control_history, 1024, "Maximum number of frames to keep control hi
 
 namespace controls
 {
-	std::map<std::string, ComboList> engine_keys;
+	KeyBindings engine_keys;
+	std::map<std::string, bool> dirty_actions; //To store if a user has changed an action's binds from the default
 	std::map<std::string, std::string> action_names;
+
 	void parse_action_names(variant node){
 		std::map<variant, variant> acts = node.as_map();
 
@@ -122,8 +124,15 @@ namespace controls
 			}
 
 			std::vector<int> temp = k;
+			if(before_index >= events.size()){
+				// List index out of range
+				return variant::from_bool(false);
+			}
 			events.insert(events.begin() + before_index, temp);
 			keys[action_name] = events;
+
+			// Assign back the modified array
+			dirty_actions[action_name] = true;
 			return variant::from_bool(true);
 		}
 		return variant::from_bool(false);
@@ -140,6 +149,10 @@ namespace controls
 			//TODO: Determine if the allocated memory for the KeyCombo at events[at_index] will be
 			// automatically freed
 			events.erase(events.begin() + at_index);
+
+			// Assign back the modified array
+			keys[action_name] = events;
+
 			return variant::from_bool(true);
 		}
 		return variant::from_bool(false);

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -528,6 +528,10 @@ namespace controls
 			if(joystick::button(2)) {
 				state.keys |= 0x40;
 			}
+			// sprint
+			if(joystick::button(3)) {
+				state.keys |= 0x80;
+			}
 
 			if(g_user_ctrl_output.is_null() == false) {
 				state.user = g_user_ctrl_output.write_json();

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -21,6 +21,7 @@
 	   distribution.
 */
 
+#include <SDL2/SDL_keycode.h>
 #ifdef _MSC_VER
 #include <winsock2.h>
 #else
@@ -46,6 +47,40 @@ PREF_INT(max_control_history, 1024, "Maximum number of frames to keep control hi
 
 namespace controls
 {
+	std::map<std::string, ComboList> engine_keys;
+
+	void apply_engine_controls(variant node)
+	{
+	    std::map<variant, variant> key_binds = node["controls"]["key_bindings"].as_map();
+	    for(auto p = key_binds.begin(); p != key_binds.end(); ++p) {
+	        std::string action_name = p->first.as_string();
+			ComboList combo_list;
+
+			printf("Action %s\n", action_name.c_str());
+
+			std::vector<variant> key_sequences = p->second.as_list();
+	        for(int i=0;i<key_sequences.size();i++){
+				std::vector<std::string> key_combo = key_sequences[i].as_list_string();
+				KeyCombination kb;
+
+	            printf("Key combo: ");
+				for(int j=0;j<key_combo.size();j++){
+					const char* key_name = key_combo[j].c_str();
+					printf("%s\n", key_name);
+					int keycode = SDL_GetKeyFromName(key_name);
+					//TODO: Handle 'unknown' key
+					if(keycode != SDLK_UNKNOWN){
+						kb.push_back(keycode);
+					}
+				}
+				combo_list.push_back(kb);
+	            printf("\n"); // print a new line after each key combination
+			}
+
+			engine_keys.insert({action_name, combo_list});
+	    }
+	}
+
 	const char** control_names()
 	{
 		static const char* names[] = { "up", "down", "left", "right", "attack", "jump", "tongue", "sprint", nullptr };
@@ -350,7 +385,6 @@ namespace controls
 			if(joystick::button(3)) {
 				state.keys |= 0x80;
 			}
-			
 
 			if(g_user_ctrl_output.is_null() == false) {
 				state.user = g_user_ctrl_output.write_json();

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -441,10 +441,6 @@ namespace controls
 			if(joystick::button(2)) {
 				state.keys |= 0x40;
 			}
-			// sprint
-			if(joystick::button(3)) {
-				state.keys |= 0x80;
-			}
 
 			if(g_user_ctrl_output.is_null() == false) {
 				state.user = g_user_ctrl_output.write_json();

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -162,6 +162,16 @@ namespace controls
 		return action_names;
 	}
 
+	void set_keys_for_action(std::string action, ComboList &combos){
+		engine_keys[action] = combos;
+	}
+
+	bool has_action(std::string action_name, KeyBindings &keys){
+		if(keys.find(action_name) == keys.end()){
+			return false;
+		}
+		return true;
+	}
 	const char** control_names()
 	{
 		static const char* names[] = { "up", "down", "left", "right", "attack", "jump", "tongue", "sprint", nullptr };

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -70,6 +70,24 @@ namespace controls
 		return variant(&result);
 	};
 
+	variant set_key_for_action(std::string action_name, int index, std::vector<int> value){
+		if (engine_keys.find(action_name) != engine_keys.end()) {
+			ComboList events = engine_keys[action_name];
+			if(index >= events.size()){
+				// List index out of range
+				return variant(0);
+			}
+
+			KeyCombination k = events[index];
+			k.clear();
+			for(int i=0;i<value.size();i++){
+				k.push_back(value[i]);
+			}
+			engine_keys[action_name][index] = k;
+			return variant(1);
+		}
+		return variant(0);
+	}
 	void apply_engine_controls(variant node)
 	{
 	    std::map<variant, variant> key_binds = node["controls"]["key_bindings"].as_map();

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -50,6 +50,16 @@ PREF_INT(max_control_history, 1024, "Maximum number of frames to keep control hi
 namespace controls
 {
 	std::map<std::string, ComboList> engine_keys;
+	std::map<std::string, std::string> action_names;
+	void parse_action_names(variant node){
+		std::map<variant, variant> acts = node.as_map();
+
+		for(auto p = acts.begin(); p!=acts.end();++p){
+			std::string act_id = p->first.as_string();
+			std::string act_name = p->second.as_string();
+			action_names.insert({act_id, act_name});
+		}
+	}
 
 	void parse_keys_from_node_into_map(variant node, std::map<std::string, ComboList> *dictionary){
 	    std::map<variant, variant> key_binds = node.as_map();
@@ -133,6 +143,10 @@ namespace controls
 			return variant::from_bool(true);
 		}
 		return variant::from_bool(false);
+	}
+
+	std::map<std::string, std::string> get_action_names(){
+		return action_names;
 	}
 
 	const char** control_names()

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -70,17 +70,13 @@ namespace controls
 		    std::string action_name = p->first.as_string();
 			ComboList combo_list;
 
-			printf("Action %s\n", action_name.c_str());
-
 			std::vector<variant> key_sequences = p->second.as_list();
 			for(int i=0;i<key_sequences.size();i++){
 				std::vector<std::string> key_combo = key_sequences[i].as_list_string();
 				KeyCombination kb;
 
-			    printf("Key combo: ");
 				for(int j=0;j<key_combo.size();j++){
 					const char* key_name = key_combo[j].c_str();
-					printf("%s\n", key_name);
 					int keycode = SDL_GetKeyFromName(key_name);
 					//TODO: Handle 'unknown' key
 					if(keycode != SDLK_UNKNOWN){
@@ -88,9 +84,7 @@ namespace controls
 					}
 				}
 				combo_list.push_back(kb);
-			    printf("\n"); // print a new line after each key combination
 			}
-			printf("Inserting key value pair %s %d\n", action_name.c_str(), combo_list[0][0]);
 			this->key_mapping.insert({action_name, combo_list});
 		}
 	};
@@ -99,7 +93,6 @@ namespace controls
 		std::vector<variant> result = {};
 
 		if (this->key_mapping.find(action_name) != this->key_mapping.end()) {
-	        printf("Action %s found.\n", action_name.c_str());
 			ComboList events = this->key_mapping[action_name];
 			for(int i=0;i<events.size();i++){
 				KeyCombination kb;
@@ -196,7 +189,6 @@ namespace controls
 		for(auto p = this->action_names.begin(); p != this->action_names.end(); ++p) {
       		std::string action_name = p->first;
         	if(this->are_bindings_default_for_action(action_name)){
-         		printf("Not writing keys for %s, as is has not been changed by user\n", action_name.c_str());
          		continue;
          	}
         	std::string preference_name = "keys_";
@@ -215,7 +207,6 @@ namespace controls
          	// For each 'keys_action' that is found in preferences.cfg
         	const variant keys_node = node[preference_name];
          	if(keys_node.is_null() == false) {
-          		printf("Found preference key %s\n", preference_name.c_str());
           		// Mark action as dirty, i.e. changed from default
           		this->set_are_bindings_default(action_name, false);
 

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -153,6 +153,7 @@ namespace controls
 			// Assign back the modified array
 			keys[action_name] = events;
 
+			dirty_actions[action_name] = true;
 			return variant::from_bool(true);
 		}
 		return variant::from_bool(false);
@@ -172,6 +173,24 @@ namespace controls
 		}
 		return true;
 	}
+	void set_are_bindings_default(std::string action_name, bool value){
+		if(value == false){
+			dirty_actions[action_name] = true;
+		} else {
+			auto itor = dirty_actions.find(action_name);
+			if (itor != dirty_actions.end()){
+				dirty_actions.erase(itor);
+			}
+		}
+	}
+
+	bool are_bindings_default_for_action(std::string action_name){
+		if (dirty_actions.find(action_name) == dirty_actions.end()) {
+			return true;
+		}
+		return false;
+	}
+
 	const char** control_names()
 	{
 		static const char* names[] = { "up", "down", "left", "right", "attack", "jump", "tongue", "sprint", nullptr };

--- a/src/controls.hpp
+++ b/src/controls.hpp
@@ -48,14 +48,15 @@ namespace controls
 
 	typedef std::vector<int> KeyCombination;
 	typedef std::vector<KeyCombination> ComboList;
+	typedef std::map<std::string, ComboList> KeyBindings;
 
 	extern std::map<std::string, ComboList> engine_keys;
 
 	void parse_keys_from_node_into_map(variant node, std::map<std::string, ComboList> *dictionary);
-	variant get_engine_keys_for_action(std::string action_name);
-	variant get_module_keys_for_action(std::string action_name);
 
-	variant set_engine_key_for_action(std::string action_name, int index, std::vector<int> value);
+	variant get_keys_for_action(std::string action_name, KeyBindings &keys);
+	variant add_key_for_action(std::string action_name, int before_index, KeyCombination value, KeyBindings &keys);
+	variant del_key_for_action(std::string action_name, int at_index, KeyBindings &keys);
 
 	const char** control_names();
 

--- a/src/controls.hpp
+++ b/src/controls.hpp
@@ -49,6 +49,7 @@ namespace controls
 	typedef std::vector<KeyCombination> ComboList;
 
 	void apply_engine_controls(variant node);
+	variant get_keys_for_action(std::string action_name);
 
 	const char** control_names();
 

--- a/src/controls.hpp
+++ b/src/controls.hpp
@@ -51,9 +51,11 @@ namespace controls
 
 	extern std::map<std::string, ComboList> engine_keys;
 
-	void parse_controls_from_node_into_map(variant node, std::map<std::string, ComboList> dictionary);
-	variant get_keys_for_action(std::string action_name);
-	variant set_key_for_action(std::string action_name, int index, std::vector<int> value);
+	void parse_keys_from_node_into_map(variant node, std::map<std::string, ComboList> *dictionary);
+	variant get_engine_keys_for_action(std::string action_name);
+	variant get_module_keys_for_action(std::string action_name);
+
+	variant set_engine_key_for_action(std::string action_name, int index, std::vector<int> value);
 
 	const char** control_names();
 

--- a/src/controls.hpp
+++ b/src/controls.hpp
@@ -58,7 +58,9 @@ namespace controls
 	variant get_keys_for_action(std::string action_name, KeyBindings &keys);
 	variant add_key_for_action(std::string action_name, int before_index, KeyCombination value, KeyBindings &keys);
 	variant del_key_for_action(std::string action_name, int at_index, KeyBindings &keys);
+	bool has_action(std::string action_name, KeyBindings &keys);
 	std::map<std::string, std::string> get_action_names();
+	void set_keys_for_action(std::string action, ComboList &combos);
 
 	const char** control_names();
 

--- a/src/controls.hpp
+++ b/src/controls.hpp
@@ -26,6 +26,7 @@
 #include <vector>
 #include <memory>
 #include <string>
+#include <map>
 
 typedef unsigned long key_type;
 
@@ -48,7 +49,9 @@ namespace controls
 	typedef std::vector<int> KeyCombination;
 	typedef std::vector<KeyCombination> ComboList;
 
-	void apply_engine_controls(variant node);
+	extern std::map<std::string, ComboList> engine_keys;
+
+	void parse_controls_from_node_into_map(variant node, std::map<std::string, ComboList> dictionary);
 	variant get_keys_for_action(std::string action_name);
 	variant set_key_for_action(std::string action_name, int index, std::vector<int> value);
 

--- a/src/controls.hpp
+++ b/src/controls.hpp
@@ -50,6 +50,7 @@ namespace controls
 
 	void apply_engine_controls(variant node);
 	variant get_keys_for_action(std::string action_name);
+	variant set_key_for_action(std::string action_name, int index, std::vector<int> value);
 
 	const char** control_names();
 

--- a/src/controls.hpp
+++ b/src/controls.hpp
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include "variant_utils.hpp"
 #include <vector>
 #include <memory>
 #include <string>
@@ -50,19 +51,33 @@ namespace controls
 	typedef std::vector<KeyCombination> ComboList;
 	typedef std::map<std::string, ComboList> KeyBindings;
 
-	extern std::map<std::string, ComboList> engine_keys;
+	class ActionBindings {
+		public:
+			ActionBindings();
+			~ActionBindings();
 
-	void parse_keys_from_node_into_map(variant node, std::map<std::string, ComboList> *dictionary);
-	void parse_action_names(variant node);
+			void parse_action_names(variant node);
+			void parse_keys(variant node);
+			variant get_keys_for_action(std::string action_name);
+			variant add_key_for_action(std::string action_name, int before_index, KeyCombination value);
+			variant del_key_for_action(std::string action_name, int at_index);
+			std::map<std::string, std::string> get_action_names();
+			void set_keys_for_action(std::string action, ComboList &combos);
 
-	variant get_keys_for_action(std::string action_name, KeyBindings &keys);
-	variant add_key_for_action(std::string action_name, int before_index, KeyCombination value, KeyBindings &keys);
-	variant del_key_for_action(std::string action_name, int at_index, KeyBindings &keys);
-	bool has_action(std::string action_name, KeyBindings &keys);
-	void set_are_bindings_default(std::string action_name, bool value);
-	bool are_bindings_default_for_action(std::string action_name);
-	std::map<std::string, std::string> get_action_names();
-	void set_keys_for_action(std::string action, ComboList &combos);
+			bool has_action(std::string action_name);
+			void set_are_bindings_default(std::string action_name, bool value);
+			bool are_bindings_default_for_action(std::string action_name);
+
+			void write_to_preferences(variant_builder *node);
+			void read_from_preferences(variant node);
+		private:
+			KeyBindings key_mapping;
+			//To store if a user has changed an action's binds from the default
+			std::map<std::string, bool> dirty_actions;
+			std::map<std::string, std::string> action_names;
+	};
+
+	extern ActionBindings engine_mappings;
 
 	const char** control_names();
 

--- a/src/controls.hpp
+++ b/src/controls.hpp
@@ -45,6 +45,11 @@ namespace controls
 		NUM_CONTROLS,
 	};
 
+	typedef std::vector<int> KeyCombination;
+	typedef std::vector<KeyCombination> ComboList;
+
+	void apply_engine_controls(variant node);
+
 	const char** control_names();
 
 	void set_mouse_to_keycode(CONTROL_ITEM item, int mouse_button);

--- a/src/controls.hpp
+++ b/src/controls.hpp
@@ -59,6 +59,8 @@ namespace controls
 	variant add_key_for_action(std::string action_name, int before_index, KeyCombination value, KeyBindings &keys);
 	variant del_key_for_action(std::string action_name, int at_index, KeyBindings &keys);
 	bool has_action(std::string action_name, KeyBindings &keys);
+	void set_are_bindings_default(std::string action_name, bool value);
+	bool are_bindings_default_for_action(std::string action_name);
 	std::map<std::string, std::string> get_action_names();
 	void set_keys_for_action(std::string action, ComboList &combos);
 

--- a/src/controls.hpp
+++ b/src/controls.hpp
@@ -53,10 +53,12 @@ namespace controls
 	extern std::map<std::string, ComboList> engine_keys;
 
 	void parse_keys_from_node_into_map(variant node, std::map<std::string, ComboList> *dictionary);
+	void parse_action_names(variant node);
 
 	variant get_keys_for_action(std::string action_name, KeyBindings &keys);
 	variant add_key_for_action(std::string action_name, int before_index, KeyCombination value, KeyBindings &keys);
 	variant del_key_for_action(std::string action_name, int at_index, KeyBindings &keys);
+	std::map<std::string, std::string> get_action_names();
 
 	const char** control_names();
 

--- a/src/custom_object_functions.cpp
+++ b/src/custom_object_functions.cpp
@@ -4455,14 +4455,31 @@ RETURN_TYPE("bool")
 	END_FUNCTION_DEF(module_launch)
 
 		//(name, min_args, max_args, helpstring)
-	FUNCTION_DEF(keys_for_action, 1, 1, "keys_for_action(string) -> list: Prints the SDL keycodes configured for engine actions.")
+	FUNCTION_DEF(get_keys_for_action, 1, 1, "get_keys_for_action(string) -> list: Prints the SDL keycodes configured for engine actions.")
 			std::string action_name = EVAL_ARG(0).as_string();
 			return controls::get_keys_for_action(action_name);
 
 			FUNCTION_ARGS_DEF
 				ARG_TYPE("string");
 			RETURN_TYPE("list");
-	END_FUNCTION_DEF(keys_for_action)
+	END_FUNCTION_DEF(get_keys_for_action)
+
+	//variant set_key_for_action(std::string action_name, int index, std::vector<int> value);
+	FUNCTION_DEF(set_key_for_action, 3, 3, "set_keys_for_action(string action_name, int index, list[int] value) -> int: Gets the key combination at 'index' of the action 'action_name' and sets it to 'value'. value is an array containing sdl keycodes which need to be pressed at the same time to trigger the actio.")
+			std::string action_name = EVAL_ARG(0).as_string();
+			int index = EVAL_ARG(1).as_int();
+			variant value = EVAL_ARG(2);
+
+			std::vector<int> c_value = value.as_list_int();
+
+			return controls::set_key_for_action(action_name, index, c_value);
+
+			FUNCTION_ARGS_DEF
+				ARG_TYPE("string");
+				ARG_TYPE("int");
+				ARG_TYPE("list");
+			RETURN_TYPE("int");
+	END_FUNCTION_DEF(set_key_for_action)
 
 	FUNCTION_DEF(eval, 1, 2, "eval(str, [arg map]): evaluate the given string as FFL")
 		variant s = EVAL_ARG(0);

--- a/src/custom_object_functions.cpp
+++ b/src/custom_object_functions.cpp
@@ -4454,6 +4454,16 @@ RETURN_TYPE("bool")
 	RETURN_TYPE("commands")
 	END_FUNCTION_DEF(module_launch)
 
+		//(name, min_args, max_args, helpstring)
+	FUNCTION_DEF(keys_for_action, 1, 1, "keys_for_action(string) -> list: Prints the SDL keycodes configured for engine actions.")
+			std::string action_name = EVAL_ARG(0).as_string();
+			return controls::get_keys_for_action(action_name);
+
+			FUNCTION_ARGS_DEF
+				ARG_TYPE("string");
+			RETURN_TYPE("list");
+	END_FUNCTION_DEF(keys_for_action)
+
 	FUNCTION_DEF(eval, 1, 2, "eval(str, [arg map]): evaluate the given string as FFL")
 		variant s = EVAL_ARG(0);
 		try {

--- a/src/custom_object_functions.cpp
+++ b/src/custom_object_functions.cpp
@@ -4457,7 +4457,7 @@ RETURN_TYPE("bool")
 		//(name, min_args, max_args, helpstring)
 	FUNCTION_DEF(get_keys_for_action, 1, 1, "get_keys_for_action(string) -> list: Prints the SDL keycodes configured for engine actions.")
 			std::string action_name = EVAL_ARG(0).as_string();
-			return controls::get_keys_for_action(action_name);
+			return controls::get_engine_keys_for_action(action_name);
 
 			FUNCTION_ARGS_DEF
 				ARG_TYPE("string");
@@ -4472,7 +4472,7 @@ RETURN_TYPE("bool")
 
 			std::vector<int> c_value = value.as_list_int();
 
-			return controls::set_key_for_action(action_name, index, c_value);
+			return controls::set_engine_key_for_action(action_name, index, c_value);
 
 			FUNCTION_ARGS_DEF
 				ARG_TYPE("string");

--- a/src/custom_object_functions.cpp
+++ b/src/custom_object_functions.cpp
@@ -4458,10 +4458,10 @@ RETURN_TYPE("bool")
 	FUNCTION_DEF(get_keys_for_action, 1, 1, "get_keys_for_action(string) -> list: Prints the SDL keycodes configured for engine actions.")
 			std::string action_name = EVAL_ARG(0).as_string();
 
-			if(controls::has_action(action_name, controls::engine_keys)){
-				return controls::get_keys_for_action(action_name, controls::engine_keys);
+			if(controls::engine_mappings.has_action(action_name)){
+				return controls::engine_mappings.get_keys_for_action(action_name);
 			} else {
-				return module::get_keys_for_action(action_name);
+				return module::get_module_mappings()->get_keys_for_action(action_name);
 			}
 
 			FUNCTION_ARGS_DEF
@@ -4476,10 +4476,10 @@ RETURN_TYPE("bool")
 
 		std::vector<int> c_value = value.as_list_int();
 
-		if(controls::has_action(action_name, controls::engine_keys)){
-			return controls::add_key_for_action(action_name, index, c_value, controls::engine_keys);
+		if(controls::engine_mappings.has_action(action_name)){
+			return controls::engine_mappings.add_key_for_action(action_name, index, c_value);
 		} else {
-			return module::add_key_for_action(action_name, index, c_value);
+			return module::get_module_mappings()->add_key_for_action(action_name, index, c_value);
 		}
 		FUNCTION_ARGS_DEF
 			ARG_TYPE("string");
@@ -4492,10 +4492,10 @@ RETURN_TYPE("bool")
 		std::string action_name = EVAL_ARG(0).as_string();
 		int index = EVAL_ARG(1).as_int();
 
-		if(controls::has_action(action_name, controls::engine_keys)){
-			return controls::del_key_for_action(action_name, index, controls::engine_keys);
+		if(controls::engine_mappings.has_action(action_name)){
+			return controls::engine_mappings.del_key_for_action(action_name, index);
 		} else {
-			return module::del_key_for_action(action_name, index);
+			return module::get_module_mappings()->del_key_for_action(action_name, index);
 		}
 
 		FUNCTION_ARGS_DEF

--- a/src/custom_object_functions.cpp
+++ b/src/custom_object_functions.cpp
@@ -4457,29 +4457,38 @@ RETURN_TYPE("bool")
 		//(name, min_args, max_args, helpstring)
 	FUNCTION_DEF(get_keys_for_action, 1, 1, "get_keys_for_action(string) -> list: Prints the SDL keycodes configured for engine actions.")
 			std::string action_name = EVAL_ARG(0).as_string();
-			return controls::get_engine_keys_for_action(action_name);
+			return module::get_keys_for_action(action_name);
 
 			FUNCTION_ARGS_DEF
 				ARG_TYPE("string");
 			RETURN_TYPE("list");
 	END_FUNCTION_DEF(get_keys_for_action)
 
-	//variant set_key_for_action(std::string action_name, int index, std::vector<int> value);
-	FUNCTION_DEF(set_key_for_action, 3, 3, "set_keys_for_action(string action_name, int index, list[int] value) -> int: Gets the key combination at 'index' of the action 'action_name' and sets it to 'value'. value is an array containing sdl keycodes which need to be pressed at the same time to trigger the actio.")
-			std::string action_name = EVAL_ARG(0).as_string();
-			int index = EVAL_ARG(1).as_int();
-			variant value = EVAL_ARG(2);
+	FUNCTION_DEF(add_key_for_action, 3, 3, "add_key_for_action(string action_name, int index_before, list[int] value: Adds the key binding 'value' for action_name")
+		std::string action_name = EVAL_ARG(0).as_string();
+		int index = EVAL_ARG(1).as_int();
+		variant value = EVAL_ARG(2);
 
-			std::vector<int> c_value = value.as_list_int();
+		std::vector<int> c_value = value.as_list_int();
 
-			return controls::set_engine_key_for_action(action_name, index, c_value);
+		return module::add_key_for_action(action_name, index, c_value);
+		FUNCTION_ARGS_DEF
+			ARG_TYPE("string");
+			ARG_TYPE("int");
+			ARG_TYPE("list");
+		RETURN_TYPE("bool");
+	END_FUNCTION_DEF(add_key_for_action)
 
-			FUNCTION_ARGS_DEF
-				ARG_TYPE("string");
-				ARG_TYPE("int");
-				ARG_TYPE("list");
-			RETURN_TYPE("int");
-	END_FUNCTION_DEF(set_key_for_action)
+	FUNCTION_DEF(del_key_for_action, 2, 2, "del_key_for_action(string action_name, int index_at): Deletes the given key binding for action_name")
+		std::string action_name = EVAL_ARG(0).as_string();
+		int index = EVAL_ARG(1).as_int();
+
+		return module::del_key_for_action(action_name, index);
+		FUNCTION_ARGS_DEF
+			ARG_TYPE("string");
+			ARG_TYPE("int");
+		RETURN_TYPE("bool");
+	END_FUNCTION_DEF(del_key_for_action)
 
 	FUNCTION_DEF(eval, 1, 2, "eval(str, [arg map]): evaluate the given string as FFL")
 		variant s = EVAL_ARG(0);

--- a/src/custom_object_functions.cpp
+++ b/src/custom_object_functions.cpp
@@ -4457,7 +4457,12 @@ RETURN_TYPE("bool")
 		//(name, min_args, max_args, helpstring)
 	FUNCTION_DEF(get_keys_for_action, 1, 1, "get_keys_for_action(string) -> list: Prints the SDL keycodes configured for engine actions.")
 			std::string action_name = EVAL_ARG(0).as_string();
-			return module::get_keys_for_action(action_name);
+
+			if(controls::has_action(action_name, controls::engine_keys)){
+				return controls::get_keys_for_action(action_name, controls::engine_keys);
+			} else {
+				return module::get_keys_for_action(action_name);
+			}
 
 			FUNCTION_ARGS_DEF
 				ARG_TYPE("string");
@@ -4471,7 +4476,11 @@ RETURN_TYPE("bool")
 
 		std::vector<int> c_value = value.as_list_int();
 
-		return module::add_key_for_action(action_name, index, c_value);
+		if(controls::has_action(action_name, controls::engine_keys)){
+			return controls::add_key_for_action(action_name, index, c_value, controls::engine_keys);
+		} else {
+			return module::add_key_for_action(action_name, index, c_value);
+		}
 		FUNCTION_ARGS_DEF
 			ARG_TYPE("string");
 			ARG_TYPE("int");
@@ -4483,7 +4492,12 @@ RETURN_TYPE("bool")
 		std::string action_name = EVAL_ARG(0).as_string();
 		int index = EVAL_ARG(1).as_int();
 
-		return module::del_key_for_action(action_name, index);
+		if(controls::has_action(action_name, controls::engine_keys)){
+			return controls::del_key_for_action(action_name, index, controls::engine_keys);
+		} else {
+			return module::del_key_for_action(action_name, index);
+		}
+
 		FUNCTION_ARGS_DEF
 			ARG_TYPE("string");
 			ARG_TYPE("int");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -538,8 +538,12 @@ int main(int argcount, char* argvec[])
 	// Load control scheme from engine's config file
 	try {
 		variant cfg = json::parse_from_file("data/controls.cfg");
-		controls::parse_action_names(cfg["controls"]["names"]);
-		controls::parse_keys_from_node_into_map(cfg["controls"]["key_bindings"], &controls::engine_keys);
+
+		controls::engine_mappings.parse_action_names(cfg["controls"]["names"]);
+		controls::engine_mappings.parse_keys(cfg["controls"]["key_bindings"]);
+
+		//controls::parse_action_names(cfg["controls"]["names"]);
+		//controls::parse_keys_from_node_into_map(cfg["controls"]["key_bindings"], &controls::engine_keys);
 	} catch(const json::ParseError& error) {
 		LOG_ERROR(error.errorMessage());
 		return 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -535,6 +535,16 @@ int main(int argcount, char* argvec[])
 
 	PreferenceData preference_data = preferences::load_preferences();
 
+
+	// Load control scheme from engine's config file
+	try {
+		variant cfg = json::parse_from_file("data/controls.cfg");
+		controls::apply_engine_controls(cfg);
+	} catch(const json::ParseError& error) {
+		LOG_ERROR(error.errorMessage());
+		return 1;
+	}
+
 	if(preference_data.error){
 		LOG_ERROR("Preference data error: " << preference_data.error_message);
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -533,7 +533,7 @@ int main(int argcount, char* argvec[])
 		module::set_core_module_name(DEFAULT_MODULE);
 	}
 
-	PreferenceData preference_data = preferences::load_preferences();
+	preferences::load_preferences();
 
 
 	// Load control scheme from engine's config file

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -533,12 +533,12 @@ int main(int argcount, char* argvec[])
 		module::set_core_module_name(DEFAULT_MODULE);
 	}
 
-	preferences::load_preferences();
-
+	PreferenceData preference_data = preferences::load_preferences();
 
 	// Load control scheme from engine's config file
 	try {
 		variant cfg = json::parse_from_file("data/controls.cfg");
+		controls::parse_action_names(cfg["controls"]["names"]);
 		controls::parse_keys_from_node_into_map(cfg["controls"]["key_bindings"], &controls::engine_keys);
 	} catch(const json::ParseError& error) {
 		LOG_ERROR(error.errorMessage());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -539,7 +539,7 @@ int main(int argcount, char* argvec[])
 	// Load control scheme from engine's config file
 	try {
 		variant cfg = json::parse_from_file("data/controls.cfg");
-		controls::apply_engine_controls(cfg);
+		controls::parse_controls_from_node_into_map(cfg["controls"]["key_bindings"], controls::engine_keys);
 	} catch(const json::ParseError& error) {
 		LOG_ERROR(error.errorMessage());
 		return 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -539,7 +539,7 @@ int main(int argcount, char* argvec[])
 	// Load control scheme from engine's config file
 	try {
 		variant cfg = json::parse_from_file("data/controls.cfg");
-		controls::parse_controls_from_node_into_map(cfg["controls"]["key_bindings"], controls::engine_keys);
+		controls::parse_keys_from_node_into_map(cfg["controls"]["key_bindings"], &controls::engine_keys);
 	} catch(const json::ParseError& error) {
 		LOG_ERROR(error.errorMessage());
 		return 1;

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -29,6 +29,7 @@
 #include "asserts.hpp"
 #include "base64.hpp"
 #include "compress.hpp"
+#include "controls.hpp"
 #include "custom_object_type.hpp"
 #include "i18n.hpp"
 #include "filesystem.hpp"
@@ -405,7 +406,8 @@ namespace module
 		auto speech_dialog_bg_color = std::make_shared<KRE::Color>(58, 61, 76, 255);
 		variant player_type;
 
-
+		std::map<std::string, controls::ComboList> module_keys = {};
+		std::map<std::string, std::string> action_names = {};
 
 		const std::string constants_path = make_base_module_path(name) + "data/constants.cfg";
 		if(sys::file_exists(constants_path)) {
@@ -514,30 +516,27 @@ namespace module
 
 		m.default_preferences = v["default_preferences"];
 		m.version_ = module_version;
-		loaded_paths().insert(loaded_paths().begin(), m);
 
-		if(initial) {
-			CustomObjectType::setPlayerVariantType(player_type);
-		}
 		if(v.has_key("controls")) {
     		if(v["controls"].has_key("names")){
       			std::map<variant, variant> action_names_variant = v["controls"]["names"].as_map();
-         		std::map<std::string, std::string> action_names = {};
 
          		for(auto p = action_names_variant.begin(); p != action_names_variant.end(); ++p) {
            			std::string action_id = p->first.as_string();
               		std::string action_name = p->second.as_string();
                 	action_names.insert({action_id, action_name});
           		}
-         		m.action_names = action_names;
     		}
+      		m.action_names = action_names;
 
             if(v["controls"].has_key("key_bindings")){
-            	controls::parse_controls_from_node_into_map(v["controls"]["key_bindings"], m.module_keys);
+            	controls::parse_keys_from_node_into_map(v["controls"]["key_bindings"], &module_keys);
             }
+            printf("%d\n", (int) module_keys.size());
+            m.module_keys = module_keys;
 
             LOG_INFO("KEYS:");
-            for (auto act_keys = begin(m.module_keys); act_keys != end(m.module_keys); act_keys++) {
+            for (auto act_keys = begin(module_keys); act_keys != end(module_keys); act_keys++) {
                 LOG_INFO(act_keys->first);
                 std::vector<std::vector<int>> key_combos = act_keys->second;
                 for(auto key_combo : key_combos){
@@ -549,6 +548,21 @@ namespace module
                 }
             }
 		}
+
+
+		loaded_paths().insert(loaded_paths().begin(), m);
+
+		if(initial) {
+			CustomObjectType::setPlayerVariantType(player_type);
+		}
+	}
+
+	std::map<std::string, controls::ComboList> get_module_keys(){
+		return loaded_paths().front().module_keys;
+	}
+
+	std::map<std::string, std::string> get_action_names(){
+		return loaded_paths().front().action_names;
 	}
 
 	std::string get_default_font()

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -557,12 +557,24 @@ namespace module
 		}
 	}
 
-	std::map<std::string, controls::ComboList> get_module_keys(){
+	controls::KeyBindings get_module_keys(){
 		return loaded_paths().front().module_keys;
 	}
 
 	std::map<std::string, std::string> get_action_names(){
 		return loaded_paths().front().action_names;
+	}
+
+	variant get_keys_for_action(std::string action_name){
+		return controls::get_keys_for_action(action_name, loaded_paths().front().module_keys);
+	}
+
+	variant add_key_for_action(std::string action_name, int before_index, controls::KeyCombination value){
+		return controls::add_key_for_action(action_name, before_index, value, loaded_paths().front().module_keys);
+	}
+
+	variant del_key_for_action(std::string action_name, int at_index){
+		return controls::del_key_for_action(action_name, at_index, loaded_paths().front().module_keys);
 	}
 
 	std::string get_default_font()

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -529,21 +529,7 @@ namespace module
             	module_mappings.parse_keys(v["controls"]["key_bindings"]);
             }
 
-            printf("%d\n", (int) module_keys.size());
             m.module_mappings = module_mappings;
-
-            LOG_INFO("KEYS:");
-            for (auto act_keys = begin(module_keys); act_keys != end(module_keys); act_keys++) {
-                LOG_INFO(act_keys->first);
-                std::vector<std::vector<int>> key_combos = act_keys->second;
-                for(auto key_combo : key_combos){
-                    LOG_INFO("[");
-                    for(auto key : key_combo){
-                        LOG_INFO(key);
-                    }
-                    LOG_INFO("]");
-                }
-            }
 		}
 
 

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -25,6 +25,7 @@
 
 #include <boost/filesystem/exception.hpp>
 #include <boost/filesystem/operations.hpp>
+#include <glm/common.hpp>
 
 #include "asserts.hpp"
 #include "base64.hpp"
@@ -517,23 +518,19 @@ namespace module
 		m.default_preferences = v["default_preferences"];
 		m.version_ = module_version;
 
+		controls::ActionBindings module_mappings;
+
 		if(v.has_key("controls")) {
     		if(v["controls"].has_key("names")){
-      			std::map<variant, variant> action_names_variant = v["controls"]["names"].as_map();
-
-         		for(auto p = action_names_variant.begin(); p != action_names_variant.end(); ++p) {
-           			std::string action_id = p->first.as_string();
-              		std::string action_name = p->second.as_string();
-                	action_names.insert({action_id, action_name});
-          		}
-    		}
-      		m.action_names = action_names;
+      			module_mappings.parse_action_names(v["controls"]["names"]);
+     		}
 
             if(v["controls"].has_key("key_bindings")){
-            	controls::parse_keys_from_node_into_map(v["controls"]["key_bindings"], &module_keys);
+            	module_mappings.parse_keys(v["controls"]["key_bindings"]);
             }
+
             printf("%d\n", (int) module_keys.size());
-            m.module_keys = module_keys;
+            m.module_mappings = module_mappings;
 
             LOG_INFO("KEYS:");
             for (auto act_keys = begin(module_keys); act_keys != end(module_keys); act_keys++) {
@@ -557,32 +554,8 @@ namespace module
 		}
 	}
 
-	controls::KeyBindings get_module_keys(){
-		return loaded_paths().front().module_keys;
-	}
-
-	std::map<std::string, std::string> get_action_names(){
-		return loaded_paths().front().action_names;
-	}
-
-	variant get_keys_for_action(std::string action_name){
-		return controls::get_keys_for_action(action_name, loaded_paths().front().module_keys);
-	}
-
-	void set_keys_for_action(std::string action_name, controls::ComboList &combos){
-		loaded_paths().front().module_keys[action_name] = combos;
-	}
-
-	variant add_key_for_action(std::string action_name, int before_index, controls::KeyCombination value){
-		return controls::add_key_for_action(action_name, before_index, value, loaded_paths().front().module_keys);
-	}
-
-	variant del_key_for_action(std::string action_name, int at_index){
-		return controls::del_key_for_action(action_name, at_index, loaded_paths().front().module_keys);
-	}
-
-	bool has_action(std::string action_name){
-		return controls::has_action(action_name, loaded_paths().front().module_keys);
+	controls::ActionBindings* get_module_mappings(){
+		return &loaded_paths().front().module_mappings;
 	}
 
 	std::string get_default_font()

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -569,12 +569,20 @@ namespace module
 		return controls::get_keys_for_action(action_name, loaded_paths().front().module_keys);
 	}
 
+	void set_keys_for_action(std::string action_name, controls::ComboList &combos){
+		loaded_paths().front().module_keys[action_name] = combos;
+	}
+
 	variant add_key_for_action(std::string action_name, int before_index, controls::KeyCombination value){
 		return controls::add_key_for_action(action_name, before_index, value, loaded_paths().front().module_keys);
 	}
 
 	variant del_key_for_action(std::string action_name, int at_index){
 		return controls::del_key_for_action(action_name, at_index, loaded_paths().front().module_keys);
+	}
+
+	bool has_action(std::string action_name){
+		return controls::has_action(action_name, loaded_paths().front().module_keys);
 	}
 
 	std::string get_default_font()

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -405,6 +405,8 @@ namespace module
 		auto speech_dialog_bg_color = std::make_shared<KRE::Color>(58, 61, 76, 255);
 		variant player_type;
 
+
+
 		const std::string constants_path = make_base_module_path(name) + "data/constants.cfg";
 		if(sys::file_exists(constants_path)) {
 			const std::string contents = sys::read_file(constants_path);
@@ -509,12 +511,43 @@ namespace module
 		modules m = {name, pretty_name, abbrev,
 					 {make_base_module_path(name), make_user_module_path(name)},
 				def_font, def_font_cjk, speech_dialog_bg_color};
+
 		m.default_preferences = v["default_preferences"];
 		m.version_ = module_version;
 		loaded_paths().insert(loaded_paths().begin(), m);
 
 		if(initial) {
 			CustomObjectType::setPlayerVariantType(player_type);
+		}
+		if(v.has_key("controls")) {
+    		if(v["controls"].has_key("names")){
+      			std::map<variant, variant> action_names_variant = v["controls"]["names"].as_map();
+         		std::map<std::string, std::string> action_names = {};
+
+         		for(auto p = action_names_variant.begin(); p != action_names_variant.end(); ++p) {
+           			std::string action_id = p->first.as_string();
+              		std::string action_name = p->second.as_string();
+                	action_names.insert({action_id, action_name});
+          		}
+         		m.action_names = action_names;
+    		}
+
+            if(v["controls"].has_key("key_bindings")){
+            	controls::parse_controls_from_node_into_map(v["controls"]["key_bindings"], m.module_keys);
+            }
+
+            LOG_INFO("KEYS:");
+            for (auto act_keys = begin(m.module_keys); act_keys != end(m.module_keys); act_keys++) {
+                LOG_INFO(act_keys->first);
+                std::vector<std::vector<int>> key_combos = act_keys->second;
+                for(auto key_combo : key_combos){
+                    LOG_INFO("[");
+                    for(auto key : key_combo){
+                        LOG_INFO(key);
+                    }
+                    LOG_INFO("]");
+                }
+            }
 		}
 	}
 

--- a/src/module.hpp
+++ b/src/module.hpp
@@ -29,6 +29,7 @@
 
 #include "Color.hpp"
 
+#include "controls.hpp"
 #include <map>
 #include <string>
 #include <vector>
@@ -57,6 +58,9 @@ namespace module
 		std::vector<std::string> included_modules_;
 
 		variant default_preferences;
+
+		std::map<std::string, std::string> action_names;
+		std::map<std::string, controls::ComboList> module_keys;
 	};
 
 

--- a/src/module.hpp
+++ b/src/module.hpp
@@ -90,6 +90,8 @@ namespace module
 	variant get_keys_for_action(std::string action_name);
 	variant add_key_for_action(std::string action_name, int before_index, controls::KeyCombination value);
 	variant del_key_for_action(std::string action_name, int at_index);
+	bool has_action(std::string action_name);
+	void set_keys_for_action(std::string action_name, controls::ComboList &combos);
 
 	std::string get_default_font();
 	const KRE::ColorPtr& get_speech_dialog_bg_color();

--- a/src/module.hpp
+++ b/src/module.hpp
@@ -60,7 +60,7 @@ namespace module
 		variant default_preferences;
 
 		std::map<std::string, std::string> action_names;
-		std::map<std::string, controls::ComboList> module_keys;
+		controls::KeyBindings module_keys;
 	};
 
 
@@ -83,8 +83,13 @@ namespace module
 	//doesn't depend on any existing files.
 	std::string map_write_path(const std::string& fname, BASE_PATH_TYPE path_type=BASE_PATH_GAME);
 
-	std::map<std::string, controls::ComboList> get_module_keys();
+	variant get_keys_for_action(std::string action_name);
+
 	std::map<std::string, std::string> get_action_names();
+	controls::KeyBindings get_module_keys();
+	variant get_keys_for_action(std::string action_name);
+	variant add_key_for_action(std::string action_name, int before_index, controls::KeyCombination value);
+	variant del_key_for_action(std::string action_name, int at_index);
 
 	std::string get_default_font();
 	const KRE::ColorPtr& get_speech_dialog_bg_color();

--- a/src/module.hpp
+++ b/src/module.hpp
@@ -83,6 +83,9 @@ namespace module
 	//doesn't depend on any existing files.
 	std::string map_write_path(const std::string& fname, BASE_PATH_TYPE path_type=BASE_PATH_GAME);
 
+	std::map<std::string, controls::ComboList> get_module_keys();
+	std::map<std::string, std::string> get_action_names();
+
 	std::string get_default_font();
 	const KRE::ColorPtr& get_speech_dialog_bg_color();
 

--- a/src/module.hpp
+++ b/src/module.hpp
@@ -59,8 +59,7 @@ namespace module
 
 		variant default_preferences;
 
-		std::map<std::string, std::string> action_names;
-		controls::KeyBindings module_keys;
+		controls::ActionBindings module_mappings;
 	};
 
 
@@ -72,6 +71,8 @@ namespace module
 	//using any other module functions to establish the dlc path we use.
 	void set_core_module_name(const std::string& module_name);
 
+	controls::ActionBindings* get_module_mappings();
+
 	const std::string get_module_name();
 	const std::string get_module_pretty_name();
 	std::string get_module_version();
@@ -82,16 +83,6 @@ namespace module
 	//maps a filename, which might have an encoded module id, otherwise uses get_module_name().
 	//doesn't depend on any existing files.
 	std::string map_write_path(const std::string& fname, BASE_PATH_TYPE path_type=BASE_PATH_GAME);
-
-	variant get_keys_for_action(std::string action_name);
-
-	std::map<std::string, std::string> get_action_names();
-	controls::KeyBindings get_module_keys();
-	variant get_keys_for_action(std::string action_name);
-	variant add_key_for_action(std::string action_name, int before_index, controls::KeyCombination value);
-	variant del_key_for_action(std::string action_name, int at_index);
-	bool has_action(std::string action_name);
-	void set_keys_for_action(std::string action_name, controls::ComboList &combos);
 
 	std::string get_default_font();
 	const KRE::ColorPtr& get_speech_dialog_bg_color();

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -874,6 +874,38 @@ namespace preferences
 		return &GameRegistry::getInstance();
 	}
 
+	void parse_controls_from_preferences_given_action_list(std::map<std::string, std::string> action_names, variant node, bool for_engine){
+		for(auto p = action_names.begin(); p != action_names.end(); ++p) {
+      		std::string action_name = p->first;
+        	std::string preference_name = "keys_";
+        	preference_name += action_name;
+
+         	// For each 'keys_action' that is found in preferences.cfg
+        	const variant keys_node = node[preference_name];
+         	if(keys_node.is_null() == false) {
+          		printf("Found preference key %s\n", preference_name.c_str());
+          		// Mark action as dirty, i.e. changed from default
+          		controls::set_are_bindings_default(action_name, false);
+
+            	// Parse the data (key combinations) from variants
+             	// to the KeyCombination type.
+            	controls::ComboList combos;
+            	std::vector<variant> temp = keys_node.as_list();
+             	for(int i=0;i<temp.size();i++){
+              		controls::KeyCombination key_combo;
+               		key_combo = temp[i].as_list_int();
+            		combos.push_back(key_combo);
+              	}
+
+              	// Assign the new bindings
+               	if(for_engine){
+               		controls::set_keys_for_action(action_name, combos);
+                } else {
+                	module::set_keys_for_action(action_name, combos);
+                }
+          	}
+		}
+	}
 	PreferenceData load_preferences()
 	{
 		std::string path;
@@ -926,6 +958,15 @@ namespace preferences
 		if(show_control_rects.is_null() == false) {
 			show_iphone_controls_ = show_control_rects.as_bool(show_iphone_controls_);
 		}
+
+		// Read controls
+		std::map<std::string, std::string> module_action_names = module::get_action_names();
+		std::map<std::string, std::string> engine_action_names = controls::get_action_names();
+
+		parse_controls_from_preferences_given_action_list(module_action_names, node, false);
+		parse_controls_from_preferences_given_action_list(engine_action_names, node, true);
+
+		// end read controls
 
 		no_sound_ = node["no_sound"].as_bool(no_sound_);
 		no_music_ = node["no_music"].as_bool(no_music_);
@@ -997,19 +1038,13 @@ namespace preferences
 		printf("%d\n", (int)action_names.size());
 		for(auto p = action_names.begin(); p != action_names.end(); ++p) {
       		std::string action_name = p->first;
+        	if(controls::are_bindings_default_for_action(action_name)){
+         		continue;
+         	}
         	printf("%s\n", action_name.c_str());
         	std::string preference_name = "keys_";
         	preference_name += action_name;
 
-         	std::vector<variant> temp = module::get_keys_for_action(action_name).as_list();
-          	printf("keys for action %d\n", (int)temp.size());
-          	for(int j=0;j<temp.size();j++){
-           		std::vector<variant> a = temp[j].as_list();
-             	printf("Key %d\n", j);
-             	for(int k=0;k<a.size();k++){
-              		printf("%d ", a[k].as_int());
-              	}
-           	}
          	node.add(preference_name, module::get_keys_for_action(action_name));
 		}
 

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -993,7 +993,7 @@ namespace preferences
 		node.add("show_iphone_controls", variant::from_bool(show_iphone_controls_));
 
 		std::map<std::string, std::string> action_names = module::get_action_names();
-		std::map<std::string, controls::ComboList> module_keys = module::get_module_keys();
+		controls::KeyBindings module_keys = module::get_module_keys();
 		printf("%d\n", (int)action_names.size());
 		for(auto p = action_names.begin(); p != action_names.end(); ++p) {
       		std::string action_name = p->first;
@@ -1001,7 +1001,7 @@ namespace preferences
         	std::string preference_name = "keys_";
         	preference_name += action_name;
 
-         	std::vector<variant> temp = controls::get_module_keys_for_action(action_name).as_list();
+         	std::vector<variant> temp = module::get_keys_for_action(action_name).as_list();
           	printf("keys for action %d\n", (int)temp.size());
           	for(int j=0;j<temp.size();j++){
            		std::vector<variant> a = temp[j].as_list();
@@ -1010,7 +1010,7 @@ namespace preferences
               		printf("%d ", a[k].as_int());
               	}
            	}
-         	node.add(preference_name, controls::get_module_keys_for_action(action_name));
+         	node.add(preference_name, module::get_keys_for_action(action_name));
 		}
 
 		for(int n = 1; n <= 3; ++n) {

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -21,6 +21,7 @@
 	   distribution.
 */
 
+#include "variant.hpp"
 #include <iostream>
 #include <algorithm>
 #include <string>
@@ -28,6 +29,7 @@
 
 #include <boost/regex.hpp>
 #include <boost/lexical_cast.hpp>
+#include <vector>
 
 #if defined __has_include
 #  if __has_include("boost/uuid/detail/sha1.hpp")
@@ -989,6 +991,27 @@ namespace preferences
 		node.add("key_jump", controls::get_keycode(controls::CONTROL_JUMP));
 		node.add("key_tongue", controls::get_keycode(controls::CONTROL_TONGUE));
 		node.add("show_iphone_controls", variant::from_bool(show_iphone_controls_));
+
+		std::map<std::string, std::string> action_names = module::get_action_names();
+		std::map<std::string, controls::ComboList> module_keys = module::get_module_keys();
+		printf("%d\n", (int)action_names.size());
+		for(auto p = action_names.begin(); p != action_names.end(); ++p) {
+      		std::string action_name = p->first;
+        	printf("%s\n", action_name.c_str());
+        	std::string preference_name = "keys_";
+        	preference_name += action_name;
+
+         	std::vector<variant> temp = controls::get_module_keys_for_action(action_name).as_list();
+          	printf("keys for action %d\n", (int)temp.size());
+          	for(int j=0;j<temp.size();j++){
+           		std::vector<variant> a = temp[j].as_list();
+             	printf("Key %d\n", j);
+             	for(int k=0;k<a.size();k++){
+              		printf("%d ", a[k].as_int());
+              	}
+           	}
+         	node.add(preference_name, controls::get_module_keys_for_action(action_name));
+		}
 
 		for(int n = 1; n <= 3; ++n) {
 			controls::CONTROL_ITEM ctrl = controls::get_mouse_keycode(n);

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -874,6 +874,24 @@ namespace preferences
 		return &GameRegistry::getInstance();
 	}
 
+	void write_controls_to_preferences(controls::KeyBindings keys, std::map<std::string, std::string> action_names, variant_builder *node, bool for_engine){
+		for(auto p = action_names.begin(); p != action_names.end(); ++p) {
+      		std::string action_name = p->first;
+        	if(controls::are_bindings_default_for_action(action_name)){
+         		printf("Not writing keys for %s, as is has not been changed by user\n", action_name.c_str());
+         		continue;
+         	}
+        	std::string preference_name = "keys_";
+        	preference_name += action_name;
+
+         	if(for_engine){
+          		node->add(preference_name, controls::get_keys_for_action(action_name, controls::engine_keys));
+          	} else {
+         		node->add(preference_name, module::get_keys_for_action(action_name));
+          	}
+		}
+	}
+
 	void parse_controls_from_preferences_given_action_list(std::map<std::string, std::string> action_names, variant node, bool for_engine){
 		for(auto p = action_names.begin(); p != action_names.end(); ++p) {
       		std::string action_name = p->first;
@@ -1033,20 +1051,13 @@ namespace preferences
 		node.add("key_tongue", controls::get_keycode(controls::CONTROL_TONGUE));
 		node.add("show_iphone_controls", variant::from_bool(show_iphone_controls_));
 
-		std::map<std::string, std::string> action_names = module::get_action_names();
+		std::map<std::string, std::string> module_actions = module::get_action_names();
+		std::map<std::string, std::string> engine_actions = controls::get_action_names();
 		controls::KeyBindings module_keys = module::get_module_keys();
-		printf("%d\n", (int)action_names.size());
-		for(auto p = action_names.begin(); p != action_names.end(); ++p) {
-      		std::string action_name = p->first;
-        	if(controls::are_bindings_default_for_action(action_name)){
-         		continue;
-         	}
-        	printf("%s\n", action_name.c_str());
-        	std::string preference_name = "keys_";
-        	preference_name += action_name;
+		controls::KeyBindings engine_keys = controls::engine_keys;
 
-         	node.add(preference_name, module::get_keys_for_action(action_name));
-		}
+		write_controls_to_preferences(module_keys, module_actions, &node, false);
+		write_controls_to_preferences(engine_keys, engine_actions, &node, true);
 
 		for(int n = 1; n <= 3; ++n) {
 			controls::CONTROL_ITEM ctrl = controls::get_mouse_keycode(n);

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -874,56 +874,6 @@ namespace preferences
 		return &GameRegistry::getInstance();
 	}
 
-	void write_controls_to_preferences(controls::KeyBindings keys, std::map<std::string, std::string> action_names, variant_builder *node, bool for_engine){
-		for(auto p = action_names.begin(); p != action_names.end(); ++p) {
-      		std::string action_name = p->first;
-        	if(controls::are_bindings_default_for_action(action_name)){
-         		printf("Not writing keys for %s, as is has not been changed by user\n", action_name.c_str());
-         		continue;
-         	}
-        	std::string preference_name = "keys_";
-        	preference_name += action_name;
-
-         	if(for_engine){
-          		node->add(preference_name, controls::get_keys_for_action(action_name, controls::engine_keys));
-          	} else {
-         		node->add(preference_name, module::get_keys_for_action(action_name));
-          	}
-		}
-	}
-
-	void parse_controls_from_preferences_given_action_list(std::map<std::string, std::string> action_names, variant node, bool for_engine){
-		for(auto p = action_names.begin(); p != action_names.end(); ++p) {
-      		std::string action_name = p->first;
-        	std::string preference_name = "keys_";
-        	preference_name += action_name;
-
-         	// For each 'keys_action' that is found in preferences.cfg
-        	const variant keys_node = node[preference_name];
-         	if(keys_node.is_null() == false) {
-          		printf("Found preference key %s\n", preference_name.c_str());
-          		// Mark action as dirty, i.e. changed from default
-          		controls::set_are_bindings_default(action_name, false);
-
-            	// Parse the data (key combinations) from variants
-             	// to the KeyCombination type.
-            	controls::ComboList combos;
-            	std::vector<variant> temp = keys_node.as_list();
-             	for(int i=0;i<temp.size();i++){
-              		controls::KeyCombination key_combo;
-               		key_combo = temp[i].as_list_int();
-            		combos.push_back(key_combo);
-              	}
-
-              	// Assign the new bindings
-               	if(for_engine){
-               		controls::set_keys_for_action(action_name, combos);
-                } else {
-                	module::set_keys_for_action(action_name, combos);
-                }
-          	}
-		}
-	}
 	PreferenceData load_preferences()
 	{
 		std::string path;
@@ -978,11 +928,10 @@ namespace preferences
 		}
 
 		// Read controls
-		std::map<std::string, std::string> module_action_names = module::get_action_names();
-		std::map<std::string, std::string> engine_action_names = controls::get_action_names();
+		controls::ActionBindings* module_mappings = module::get_module_mappings();
 
-		parse_controls_from_preferences_given_action_list(module_action_names, node, false);
-		parse_controls_from_preferences_given_action_list(engine_action_names, node, true);
+		controls::engine_mappings.read_from_preferences(node);
+		module_mappings->read_from_preferences(node);
 
 		// end read controls
 
@@ -1051,13 +1000,10 @@ namespace preferences
 		node.add("key_tongue", controls::get_keycode(controls::CONTROL_TONGUE));
 		node.add("show_iphone_controls", variant::from_bool(show_iphone_controls_));
 
-		std::map<std::string, std::string> module_actions = module::get_action_names();
-		std::map<std::string, std::string> engine_actions = controls::get_action_names();
-		controls::KeyBindings module_keys = module::get_module_keys();
-		controls::KeyBindings engine_keys = controls::engine_keys;
+		controls::ActionBindings* module_mappings = module::get_module_mappings();
 
-		write_controls_to_preferences(module_keys, module_actions, &node, false);
-		write_controls_to_preferences(engine_keys, engine_actions, &node, true);
+		controls::engine_mappings.write_to_preferences(&node);
+		module_mappings->write_to_preferences(&node);
 
 		for(int n = 1; n <= 3; ++n) {
 			controls::CONTROL_ITEM ctrl = controls::get_mouse_keycode(n);


### PR DESCRIPTION
Implements stage 1 of https://github.com/frogatto/frogatto/issues/685#issuecomment-1625035462, i.e.
> We get the new input working with keys. No buttons, no axes. This includes being able to do remapping from the debug console by setting something. And saving the remapping as a preference. Notably, we're skipping event dispatch and controller support here

Tied to https://github.com/frogatto/frogatto/pull/737.
<details>
<summary><b>File changes:</b></summary>

Add `data/controls.cfg` to anura folder. This stores the base engine actions (up/left/down/right/confirm/cancel) and their corresponding SDL key strings(They are converted to SDL keycodes when the file is read), as well as the names of the actions.
There is a similar structure in `modules/frogatto4/module.cfg` which describes the (additional) actions defined by the module. These include jump/tongue/pane_left/pane_right.

Both  engine and module actions are stored in the user's `preferences.cfg`. Importantly:
1. If a user removes or edits an action, any default mappings from `anura/controls.cfg` or `frogatto4/module.cfg` are ignored *even if* the user then changes the mappings to match the default keys.
2. If anura or the frogatto module adds a new action, or modifies an existing action, these changes will be applied if the user has not deviated from the default bindings. See point No. 1
</details>

<details>
<summary><b>Code changes:</b></summary>

A new class called `ActionBindings` keeps track of the actions and the keys they correspond to. One object in `controls.cpp:engine_mapping`, and another in `module.cpp::modules.module_mapping`.


* `void parse_action_names` - parse the action names dict. from a given `node`, and store them in the `action_names` dict.
* `void parse_keys` - same as above, but for applying the key bindings. Data stored in `key_mapping` dict.
* `variant get_keys_for_action(std::string action_name)` - For use with FFL. Returns a list of list of SDL keycodes mapped to a given action. There is an extra 'list of' here, because I needed a way to describe combinations like Ctrl+P which involve pressing multiple keys at once.
* `variant add_key_for_action(std::string action_name, int before_index, KeyCombination value` - For use with FFL. Adds a key combination to the `key_mapping` dict.
* `variant del_key_for_action(std::string action_name, int at_index)` - For use with FFL. Deletes a key combination from the `key_mapping` dict
* `get_action_names` - get dict of action ids to action names
* `bool are_bindings_default_for_action(std::string action_name)` - returns `true` if the action's key bindings have not chbeen changed from the default
* `void set_are_bindings_default(std::string action_name, bool value)` - manually toggle the 'dirty' flag for a given action
* `bool has_action(std::string action_name)` - returns true if `action_names` has a given action
* `void set_keys_for_action(std::string action, ComboList &combos)` - set the key combinations for a given action. Used in `preferences.cpp`.
* `write_to_preferences(variant node)`
* `read_from_preferences(variant_builder node)`

`preferences.cpp`:
* Add code to get the loaded module and store the keycodes for all the configured actions. Actions which have not changed from the default are *not stored*. The format for actions stored is like so:
```
        "keys_inventory": [
		[105]
	],
	"keys_item": [
		[100]
	],
	"keys_pause": [[1073742048, 112], [1073742052, 112]],
	"keys_pane-right": [
		[119]
	],
	"keys_sprint": [
		[1073742049]
	],
	"keys_tongue": [
		[115]
	],
```

</summary>

The important ffl commands are:

* `get_keys_for_action(string action_name)`
* `add_key_for_action(string action_name, int before_index, list[int] value) -> bool`
* `del_key_for_action(string action_name, int at_index)  -> bool`