### PR TITLE
Stop caching on pushes to trunk

### DIFF
--- a/.github/workflows/pr-smoketest-alma.yaml
+++ b/.github/workflows/pr-smoketest-alma.yaml
@@ -1,9 +1,6 @@
 name: Smoketest / Informative / Alma
 on:
   pull_request:
-  push:
-    branches:
-      - trunk
   schedule:
     - cron: '0 0 * * 0' # Weekly on Sunday
 
@@ -72,12 +69,12 @@ jobs:
       - name: Checkout Anura
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      # Only write to cache on pushes to trunk
+      # Only write to cache on scheduled builds on trunk
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2.20
         with:
           key: ${{ github.job }}-alma-${{ matrix.alma }}-${{ matrix.compiler }}-${{ matrix.build-type }}
-          save: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/trunk' }}
+          save: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-smoketest-debian.yaml
+++ b/.github/workflows/pr-smoketest-debian.yaml
@@ -1,9 +1,6 @@
 name: Smoketest / Informative / Debian
 on:
   pull_request:
-  push:
-    branches:
-      - trunk
   schedule:
     - cron: '0 0 * * 0' # Weekly on Sunday
 
@@ -62,12 +59,12 @@ jobs:
       - name: Checkout Anura
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      # Only write to cache on pushes to trunk
+      # Only write to cache on scheduled builds on trunk
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2.20
         with:
           key: ${{ github.job }}-debian-${{ matrix.debian }}-${{ matrix.compiler }}-${{ matrix.build-type }}
-          save: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/trunk' }}
+          save: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-smoketest-fedora.yaml
+++ b/.github/workflows/pr-smoketest-fedora.yaml
@@ -1,9 +1,6 @@
 name: Smoketest / Informative / Fedora
 on:
   pull_request:
-  push:
-    branches:
-      - trunk
   schedule:
     - cron: '0 0 * * 0' # Weekly on Sunday
 
@@ -59,12 +56,12 @@ jobs:
       - name: Checkout Anura
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      # Only write to cache on pushes to trunk
+      # Only write to cache on scheduled builds on trunk
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2.20
         with:
           key: ${{ github.job }}-fedora-${{ matrix.fedora }}-${{ matrix.compiler }}-${{ matrix.build-type }}
-          save: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/trunk' }}
+          save: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-smoketest-opensuse-leap.yaml
+++ b/.github/workflows/pr-smoketest-opensuse-leap.yaml
@@ -1,9 +1,6 @@
 name: Smoketest / Informative / openSUSE Leap
 on:
   pull_request:
-  push:
-    branches:
-      - trunk
   schedule:
     - cron: '0 0 * * 0' # Weekly on Sunday
 
@@ -61,12 +58,12 @@ jobs:
       - name: Checkout Anura
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      # Only write to cache on pushes to trunk and scheduled builds on trunk
+      # Only write to cache on scheduled builds on trunk
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2.20
         with:
           key: ${{ github.job }}-opensuse-leap-${{ matrix.suse }}-${{ matrix.compiler }}-${{ matrix.build-type }}
-          save: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/trunk' }}
+          save: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-smoketest-rocky.yaml
+++ b/.github/workflows/pr-smoketest-rocky.yaml
@@ -1,9 +1,6 @@
 name: Smoketest / Informative / Rocky
 on:
   pull_request:
-  push:
-    branches:
-      - trunk
   schedule:
     - cron: '0 0 * * 0' # Weekly on Sunday
 
@@ -72,12 +69,12 @@ jobs:
       - name: Checkout Anura
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      # Only write to cache on pushes to trunk
+      # Only write to cache on scheduled builds on trunk
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2.20
         with:
           key: ${{ github.job }}-rocky-${{ matrix.rocky }}-${{ matrix.compiler }}-${{ matrix.build-type }}
-          save: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/trunk' }}
+          save: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-smoketest-ubuntu.yaml
+++ b/.github/workflows/pr-smoketest-ubuntu.yaml
@@ -1,9 +1,6 @@
 name: Smoketest / Informative / Ubuntu
 on:
   pull_request:
-  push:
-    branches:
-      - trunk
   schedule:
     - cron: '0 0 * * 0' # Weekly on Sunday
 
@@ -63,12 +60,12 @@ jobs:
       - name: Checkout Anura
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      # Only write to cache on pushes to trunk
+      # Only write to cache on scheduled builds on trunk
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2.20
         with:
           key: ${{ github.job }}-ubuntu-${{ matrix.ubuntu }}-${{ matrix.compiler }}-${{ matrix.build-type }}
-          save: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/trunk' }}
+          save: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-unit-tests-dynamic-linux.yaml
+++ b/.github/workflows/pr-unit-tests-dynamic-linux.yaml
@@ -2,9 +2,6 @@ name: Unit Tests / Required / Dynamic / Linux
 on:
   pull_request:
   merge_group:
-  push:
-    branches:
-      - trunk
   schedule:
     - cron: '0 0 * * 0' # Weekly on Sunday
 
@@ -51,12 +48,12 @@ jobs:
       - name: Checkout Anura
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      # Only write to cache on pushes to trunk
+      # Only write to cache on scheduled builds on trunk
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2.20
         with:
           key: unit-tests-linux-${{ matrix.build-type }}-${{ matrix.runner }}
-          save: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/trunk' }}
+          save: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-unit-tests-static-linux.yaml
+++ b/.github/workflows/pr-unit-tests-static-linux.yaml
@@ -2,9 +2,6 @@ name: Unit Tests / Required / Static / Linux
 on:
   pull_request:
   merge_group:
-  push:
-    branches:
-      - trunk
   schedule:
     - cron: '0 0 * * 0' # Weekly on Sunday
 
@@ -50,12 +47,12 @@ jobs:
       - name: Ignore Filesystem Permissions for Git
         run: git config --global --add safe.directory '*'
 
-      # Only write to cache on pushes to trunk
+      # Only write to cache on scheduled builds on trunk
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2.20
         with:
           key: unit-tests-linux-static-steam-${{ matrix.build-type }}-${{ matrix.compiler }}-${{ matrix.steam-runtime }}
-          save: ${{ (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/trunk' }}
+          save: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
 
       - name: Install Conan
         uses: conan-io/setup-conan@09566912d661de90608308897a4d513e850c04e8 # v1.2.0

--- a/README.md
+++ b/README.md
@@ -424,8 +424,8 @@ the compute we spend on a per push basis.
 
 The resulting caching strategy going forwards:
 
-* Cache on all pushes to the default branch `trunk` to refresh new objects
-* Cache on Sundays to ensure we have some hot 10GB set within the 7d limit
+* Write to cache on Sundays to ensure we always have some hot 10GB set within the 7d limit
+* Consume from cache on all builds
 
 ## CD
 


### PR DESCRIPTION
We're causing a CI clogging build storm every time we merge many things at once.

It's good enough to consume from the weekly scheduled cache build job.