### PR TITLE
Dependabot: use a GitHub App token for approving and merging

### DIFF
--- a/.github/workflows/pr-dependabot-auto-approve.yaml
+++ b/.github/workflows/pr-dependabot-auto-approve.yaml
@@ -10,8 +10,14 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
+      - name: Create app token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: app-token
+        with:
+          app-id: ${{ secrets.AUTOAPPROVE_APP_ID }}
+          private-key: ${{ secrets.AUTOAPPROVE_APP_PRIVATE_KEY }}
       - name: Auto Approve Dependabot PRs
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: gh pr review --approve "$PR_URL"

--- a/.github/workflows/pr-dependabot-auto-merge.yaml
+++ b/.github/workflows/pr-dependabot-auto-merge.yaml
@@ -11,8 +11,14 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
+      - name: Create app token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: app-token
+        with:
+          app-id: ${{ secrets.AUTOAPPROVE_APP_ID }}
+          private-key: ${{ secrets.AUTOAPPROVE_APP_PRIVATE_KEY }}
       - name: Enable Auto Merge for Dependabot PRs
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
Some upstream change to infinite loop prevention broke the previous method.

We have a GitHub App for this now and thus we use a non-default automation identity to approve and merge PRs from Dependabot. This should restore the builds for those merges actually triggering in the merge queue.