### PR TITLE
Caching: only save on weekly schedule, consume elsewhere

### DIFF
--- a/.github/workflows/pr-smoketest-alma.yaml
+++ b/.github/workflows/pr-smoketest-alma.yaml
@@ -81,11 +81,14 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       # Only write to cache on scheduled builds on trunk
+      # Don't restore when creating and saving cache
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2.20
         with:
           key: ${{ github.job }}-alma-${{ matrix.alma }}-${{ matrix.compiler }}-${{ matrix.build-type }}
+          append-timestamp: false
           save: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
+          restore: ! ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-smoketest-alma.yaml
+++ b/.github/workflows/pr-smoketest-alma.yaml
@@ -2,7 +2,7 @@ name: Smoketest / Informative / Alma
 on:
   pull_request:
   schedule:
-    - cron: '0 0 * * 0' # Weekly on Sunday
+    - cron: "0 0 * * 0" # Weekly on Sunday
 
 jobs:
   test:

--- a/.github/workflows/pr-smoketest-alma.yaml
+++ b/.github/workflows/pr-smoketest-alma.yaml
@@ -50,32 +50,32 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-            dnf -qy update
-            # We need to add an extra command to DNF to manage its config
-            dnf install -qy 'dnf-command(config-manager)'
-            # We need either PowerTools or CodeReady Builder
-            # Alma 8 has PowerTools, Alma 9 has CodeReady Builder
-            dnf config-manager --set-enabled powertools || dnf config-manager --set-enabled crb
-            # We need packages from EPEL
-            dnf install -qy epel-release
-            dnf install -qy \
-              git \
-              cmake \
-              gcc-c++ \
-              clang \
-              ccache \
-              boost-devel \
-              zlib-devel \
-              mesa-libGL-devel \
-              glew-devel \
-              freetype-devel \
-              SDL2-devel \
-              SDL2_image-devel \
-              SDL2_mixer-devel \
-              SDL2_ttf-devel \
-              libogg-devel \
-              libvorbis-devel \
-              cairo-devel
+          dnf -qy update
+          # We need to add an extra command to DNF to manage its config
+          dnf install -qy 'dnf-command(config-manager)'
+          # We need either PowerTools or CodeReady Builder
+          # Alma 8 has PowerTools, Alma 9 has CodeReady Builder
+          dnf config-manager --set-enabled powertools || dnf config-manager --set-enabled crb
+          # We need packages from EPEL
+          dnf install -qy epel-release
+          dnf install -qy \
+            git \
+            cmake \
+            gcc-c++ \
+            clang \
+            ccache \
+            boost-devel \
+            zlib-devel \
+            mesa-libGL-devel \
+            glew-devel \
+            freetype-devel \
+            SDL2-devel \
+            SDL2_image-devel \
+            SDL2_mixer-devel \
+            SDL2_ttf-devel \
+            libogg-devel \
+            libvorbis-devel \
+            cairo-devel
 
       - name: Checkout Anura
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/pr-smoketest-debian.yaml
+++ b/.github/workflows/pr-smoketest-debian.yaml
@@ -60,11 +60,14 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       # Only write to cache on scheduled builds on trunk
+      # Don't restore when creating and saving cache
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2.20
         with:
           key: ${{ github.job }}-debian-${{ matrix.debian }}-${{ matrix.compiler }}-${{ matrix.build-type }}
+          append-timestamp: false
           save: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
+          restore: ! ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-smoketest-debian.yaml
+++ b/.github/workflows/pr-smoketest-debian.yaml
@@ -2,7 +2,7 @@ name: Smoketest / Informative / Debian
 on:
   pull_request:
   schedule:
-    - cron: '0 0 * * 0' # Weekly on Sunday
+    - cron: "0 0 * * 0" # Weekly on Sunday
 
 jobs:
   test:

--- a/.github/workflows/pr-smoketest-fedora.yaml
+++ b/.github/workflows/pr-smoketest-fedora.yaml
@@ -36,22 +36,22 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-            dnf -qy update
-            dnf -qy install \
-                git \
-                g++ \
-                clang \
-                cmake \
-                make \
-                ccache \
-                boost-devel \
-                cairo-devel \
-                glew-devel \
-                libvorbis-devel \
-                SDL2_image-devel \
-                SDL2_mixer-devel \
-                SDL2_ttf-devel \
-                SDL2-devel
+          dnf -qy update
+          dnf -qy install \
+              git \
+              g++ \
+              clang \
+              cmake \
+              make \
+              ccache \
+              boost-devel \
+              cairo-devel \
+              glew-devel \
+              libvorbis-devel \
+              SDL2_image-devel \
+              SDL2_mixer-devel \
+              SDL2_ttf-devel \
+              SDL2-devel
 
       - name: Checkout Anura
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/pr-smoketest-fedora.yaml
+++ b/.github/workflows/pr-smoketest-fedora.yaml
@@ -57,11 +57,14 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       # Only write to cache on scheduled builds on trunk
+      # Don't restore when creating and saving cache
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2.20
         with:
           key: ${{ github.job }}-fedora-${{ matrix.fedora }}-${{ matrix.compiler }}-${{ matrix.build-type }}
+          append-timestamp: false
           save: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
+          restore: ! ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-smoketest-fedora.yaml
+++ b/.github/workflows/pr-smoketest-fedora.yaml
@@ -2,7 +2,7 @@ name: Smoketest / Informative / Fedora
 on:
   pull_request:
   schedule:
-    - cron: '0 0 * * 0' # Weekly on Sunday
+    - cron: "0 0 * * 0" # Weekly on Sunday
 
 jobs:
   test:

--- a/.github/workflows/pr-smoketest-opensuse-leap.yaml
+++ b/.github/workflows/pr-smoketest-opensuse-leap.yaml
@@ -59,11 +59,14 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       # Only write to cache on scheduled builds on trunk
+      # Don't restore when creating and saving cache
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2.20
         with:
           key: ${{ github.job }}-opensuse-leap-${{ matrix.suse }}-${{ matrix.compiler }}-${{ matrix.build-type }}
+          append-timestamp: false
           save: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
+          restore: ! ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-smoketest-opensuse-leap.yaml
+++ b/.github/workflows/pr-smoketest-opensuse-leap.yaml
@@ -2,7 +2,7 @@ name: Smoketest / Informative / openSUSE Leap
 on:
   pull_request:
   schedule:
-    - cron: '0 0 * * 0' # Weekly on Sunday
+    - cron: "0 0 * * 0" # Weekly on Sunday
 
 jobs:
   test:

--- a/.github/workflows/pr-smoketest-rocky.yaml
+++ b/.github/workflows/pr-smoketest-rocky.yaml
@@ -50,32 +50,32 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
-            dnf -qy update
-            # We need to add an extra command to DNF to manage its config
-            dnf install -qy 'dnf-command(config-manager)'
-            # We need either PowerTools or CodeReady Builder
-            # Rocky 8 has PowerTools, Rocky 9 has CodeReady Builder
-            dnf config-manager --set-enabled powertools || dnf config-manager --set-enabled crb
-            # We need packages from EPEL
-            dnf install -qy epel-release
-            dnf install -qy \
-              git \
-              cmake \
-              gcc-c++ \
-              clang \
-              ccache \
-              boost-devel \
-              zlib-devel \
-              mesa-libGL-devel \
-              glew-devel \
-              freetype-devel \
-              SDL2-devel \
-              SDL2_image-devel \
-              SDL2_mixer-devel \
-              SDL2_ttf-devel \
-              libogg-devel \
-              libvorbis-devel \
-              cairo-devel
+          dnf -qy update
+          # We need to add an extra command to DNF to manage its config
+          dnf install -qy 'dnf-command(config-manager)'
+          # We need either PowerTools or CodeReady Builder
+          # Rocky 8 has PowerTools, Rocky 9 has CodeReady Builder
+          dnf config-manager --set-enabled powertools || dnf config-manager --set-enabled crb
+          # We need packages from EPEL
+          dnf install -qy epel-release
+          dnf install -qy \
+            git \
+            cmake \
+            gcc-c++ \
+            clang \
+            ccache \
+            boost-devel \
+            zlib-devel \
+            mesa-libGL-devel \
+            glew-devel \
+            freetype-devel \
+            SDL2-devel \
+            SDL2_image-devel \
+            SDL2_mixer-devel \
+            SDL2_ttf-devel \
+            libogg-devel \
+            libvorbis-devel \
+            cairo-devel
 
       - name: Checkout Anura
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/pr-smoketest-rocky.yaml
+++ b/.github/workflows/pr-smoketest-rocky.yaml
@@ -81,11 +81,14 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       # Only write to cache on scheduled builds on trunk
+      # Don't restore when creating and saving cache
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2.20
         with:
           key: ${{ github.job }}-rocky-${{ matrix.rocky }}-${{ matrix.compiler }}-${{ matrix.build-type }}
+          append-timestamp: false
           save: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
+          restore: ! ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-smoketest-rocky.yaml
+++ b/.github/workflows/pr-smoketest-rocky.yaml
@@ -2,7 +2,7 @@ name: Smoketest / Informative / Rocky
 on:
   pull_request:
   schedule:
-    - cron: '0 0 * * 0' # Weekly on Sunday
+    - cron: "0 0 * * 0" # Weekly on Sunday
 
 jobs:
   test:

--- a/.github/workflows/pr-smoketest-ubuntu.yaml
+++ b/.github/workflows/pr-smoketest-ubuntu.yaml
@@ -61,11 +61,14 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       # Only write to cache on scheduled builds on trunk
+      # Don't restore when creating and saving cache
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2.20
         with:
           key: ${{ github.job }}-ubuntu-${{ matrix.ubuntu }}-${{ matrix.compiler }}-${{ matrix.build-type }}
+          append-timestamp: false
           save: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
+          restore: ! ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-smoketest-ubuntu.yaml
+++ b/.github/workflows/pr-smoketest-ubuntu.yaml
@@ -2,7 +2,7 @@ name: Smoketest / Informative / Ubuntu
 on:
   pull_request:
   schedule:
-    - cron: '0 0 * * 0' # Weekly on Sunday
+    - cron: "0 0 * * 0" # Weekly on Sunday
 
 jobs:
   test:

--- a/.github/workflows/pr-unit-tests-dynamic-linux.yaml
+++ b/.github/workflows/pr-unit-tests-dynamic-linux.yaml
@@ -49,11 +49,14 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       # Only write to cache on scheduled builds on trunk
+      # Don't restore when creating and saving cache
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2.20
         with:
           key: unit-tests-linux-${{ matrix.build-type }}-${{ matrix.runner }}
+          append-timestamp: false
           save: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
+          restore: ! ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
 
       - name: Build Prep Anura
         run: |

--- a/.github/workflows/pr-unit-tests-dynamic-linux.yaml
+++ b/.github/workflows/pr-unit-tests-dynamic-linux.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
   merge_group:
   schedule:
-    - cron: '0 0 * * 0' # Weekly on Sunday
+    - cron: "0 0 * * 0" # Weekly on Sunday
 
 jobs:
   test:

--- a/.github/workflows/pr-unit-tests-static-linux.yaml
+++ b/.github/workflows/pr-unit-tests-static-linux.yaml
@@ -48,25 +48,27 @@ jobs:
         run: git config --global --add safe.directory '*'
 
       # Only write to cache on scheduled builds on trunk
+      # Don't restore when creating and saving cache
       - name: Set ccache up
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2.20
         with:
           key: unit-tests-linux-static-steam-${{ matrix.build-type }}-${{ matrix.compiler }}-${{ matrix.steam-runtime }}
+          append-timestamp: false
           save: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
+          restore: ! ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/trunk' }}
 
       - name: Install Conan
         uses: conan-io/setup-conan@09566912d661de90608308897a4d513e850c04e8 # v1.2.0
         with:
           use_venv: true
 
-      # Always restore cache
+      # Don't restore when creating and saving cache
       - name: Restore Conan Cache
+        if: ! github.event_name == 'schedule' && github.ref == 'refs/heads/trunk'
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: ~/.conan2/p
           key: conan-linux-static-steam-${{ matrix.build-type }}-${{ matrix.compiler }}-${{ matrix.steam-runtime }}
-          restore-keys: |
-            conan-linux-static-steam-${{ matrix.build-type }}-${{ matrix.compiler }}-${{ matrix.steam-runtime }}-
 
       - name: Install Dependencies with Conan
         run: |
@@ -77,9 +79,9 @@ jobs:
             --build='b2/*' \
             --build=missing
 
-      # Only write to cache on pushes to trunk
+      # Only write to cache on scheduled builds on trunk
       - name: Save Conan Cache
-        if: github.event_name == 'push' && github.ref == 'refs/heads/trunk'
+        if: github.event_name == 'schedule' && github.ref == 'refs/heads/trunk'
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: ~/.conan2/p

--- a/.github/workflows/pr-unit-tests-static-linux.yaml
+++ b/.github/workflows/pr-unit-tests-static-linux.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
   merge_group:
   schedule:
-    - cron: '0 0 * * 0' # Weekly on Sunday
+    - cron: "0 0 * * 0" # Weekly on Sunday
 
 jobs:
   build:


### PR DESCRIPTION
* Remove timestamps from ccache caches for stable cache keys
* Only save caches on the weekly schedule on default branch
* Don't restore caches on cache rebuilds to ensure fresh caches
* Restore caches in all other circumstances