### PR TITLE
Dependabot: wait for all builds to succeed before approving

### DIFF
--- a/.github/workflows/pr-dependabot-auto-approve.yaml
+++ b/.github/workflows/pr-dependabot-auto-approve.yaml
@@ -16,6 +16,11 @@ jobs:
         with:
           app-id: ${{ secrets.AUTOAPPROVE_APP_ID }}
           private-key: ${{ secrets.AUTOAPPROVE_APP_PRIVATE_KEY }}
+      - name: Wait for status checks
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh pr checks "$PR_URL" --watch --interval 30
       - name: Auto Approve Dependabot PRs
         env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/pr-dependabot-auto-merge.yaml
+++ b/.github/workflows/pr-dependabot-auto-merge.yaml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   dependabot-auto-merge:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Create app token


### PR DESCRIPTION
For dependency changes, especially if we start managing Conan dependencies in the future, I'd also like all optional builds to to be green before pulling the trigger on a merge.

Flagging the automerge without waiting is still fine to do as the approval then simply immediately queues the job into the merge queue when it's fully ready (and likely not in the middle of a build storm, making the queue move faster with the required builds).

Also flipped the automerge job to use the new slim runners as it is IO bound and quick.

https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/

The approval job will wait for so long it will not fit within the 15 minute budget the new slim runners have.

https://docs.github.com/en/actions/reference/runners/github-hosted-runners#usage-limits