### PR TITLE
Static Steam Linux Build: force building of m4

### DIFF
--- a/.github/workflows/pr-unit-tests-static-linux.yaml
+++ b/.github/workflows/pr-unit-tests-static-linux.yaml
@@ -77,6 +77,7 @@ jobs:
             -s build_type="${{ matrix.build-type }}" \
             -s compiler.cppstd=17 \
             --build='b2/*' \
+            --build='m4/*' \
             --build=missing
 
       # Only write to cache on scheduled builds on trunk


### PR DESCRIPTION
Conan silently swapped to using a newer cached version of m4, which is now too new for the glibc the old steam runtime containers ship.