### PR TITLE
Flip autoapprove back to default runners

### DIFF
--- a/.github/workflows/pr-dependabot-auto-approve.yaml
+++ b/.github/workflows/pr-dependabot-auto-approve.yaml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   dependabot-auto-approve:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Create app token


### PR DESCRIPTION
Turns out the slim runners have a 15min max time.