### PR TITLE
Add smoketests for Ubuntu 26.04

### DIFF
--- a/.github/workflows/pr-smoketest-alma.yaml
+++ b/.github/workflows/pr-smoketest-alma.yaml
@@ -12,20 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # 8 is the oldest Alma Linux to exist
-          - alma: "8"
-            compiler: g++
-            build-type: Debug
-          - alma: "8"
-            compiler: g++
-            build-type: Release
-          - alma: "8"
-            compiler: clang++
-            build-type: Debug
-          - alma: "8"
-            compiler: clang++
-            build-type: Release
-          # Alma 9 ships Clang 20 and that cannot build against Boost MPL older than 1.86, and Alma 9 ships 1.75
+          # 9 is the oldest Alma Linux with a new enough libboost
+          # 9 ships Clang 20 and that cannot build against Boost MPL older than 1.86, and Alma 9 ships 1.75
           - alma: "9"
             compiler: g++
             build-type: Debug

--- a/.github/workflows/pr-smoketest-fedora.yaml
+++ b/.github/workflows/pr-smoketest-fedora.yaml
@@ -12,11 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         fedora:
-          # Fedora 33 is the oldest Fedora with a new enough CMake for our FetchContent workarounds
-          - "33"
-          - "34"
-          - "35"
-          - "36"
+          # 37 is the oldest Fedora with a new enough libboost
           - "37"
           - "38"
           - "39"

--- a/.github/workflows/pr-smoketest-opensuse-leap.yaml
+++ b/.github/workflows/pr-smoketest-opensuse-leap.yaml
@@ -12,10 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         suse:
-          # 15.4 is the oldest openSUSE Leap with a new enough clang
-          - "15.4"
-          - "15.5"
-          - "15.6"
+          # 16.0 is the oldest openSUSE Leap with a new enough libboost
           - "16.0"
           # 16.1 is expected in 2026-06
           # 16.2 is expected in 2027-06

--- a/.github/workflows/pr-smoketest-rocky.yaml
+++ b/.github/workflows/pr-smoketest-rocky.yaml
@@ -12,19 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # 8 is the oldest Rocky Linux to exist
-          - rocky: "8"
-            compiler: g++
-            build-type: Debug
-          - rocky: "8"
-            compiler: g++
-            build-type: Release
-          - rocky: "8"
-            compiler: clang++
-            build-type: Debug
-          - rocky: "8"
-            compiler: clang++
-            build-type: Release
+          # 9 is the oldest Rocky Linux with a new enough libboost
           # Rocky 9 ships Clang 20 and that cannot build against Boost MPL older than 1.86, and Rocky 9 ships 1.75
           - rocky: "9"
             compiler: g++

--- a/.github/workflows/pr-smoketest-ubuntu.yaml
+++ b/.github/workflows/pr-smoketest-ubuntu.yaml
@@ -16,8 +16,9 @@ jobs:
           # 22.04 is the oldest LTS with a new enough CMake for our FetchContent workarounds
           - "22.04"
           - "24.04"
-          # 26.04 LTS is expected in 2026-04
+          - "26.04"
           # 28.04 LTS is expected in 2028-04
+          # 30.04 LTS is expected in 2030-04
         compiler:
           - g++
           - clang++

--- a/README.md
+++ b/README.md
@@ -347,11 +347,8 @@ On Pull Requests:
   * Ubuntu
     * 22.04 / Jammy Jellyfish
     * 24.04 / Noble Numbat
+    * 26.04 / Resolute Raccoon
   * Fedora
-    * 33
-    * 34
-    * 35
-    * 36
     * 37
     * 38
     * 39
@@ -360,17 +357,12 @@ On Pull Requests:
     * 42
     * 43
   * Rocky Linux
-    * 8
     * 9
     * 10
   * Alma Linux
-    * 8
     * 9
     * 10
   * openSUSE Leap
-    * 15.4
-    * 15.5
-    * 15.6
     * 16.0
 
 This set should cover most popular use cases and also derivative distributions

--- a/buildsystem/linux-dynamic/CMakeLists.txt
+++ b/buildsystem/linux-dynamic/CMakeLists.txt
@@ -111,8 +111,13 @@ file(
 
 # https://cmake.org/cmake/help/v3.12/module/FindThreads.html
 find_package(Threads REQUIRED)
-# https://cmake.org/cmake/help/v3.12/module/FindBoost.html
-find_package(Boost REQUIRED COMPONENTS filesystem locale regex system)
+# Require Boost 1.70+ and use Boost's CONFIG package instead of CMake's legacy
+# FindBoost module.
+#
+# We do this because CMake's FindBoost path is being removed in newer CMake
+# releases (CMP0167), and Boost 1.90+ / distro packaging changes mean the old
+# component-based lookup for `system` is no longer reliable across our CI matrix.
+find_package(Boost CONFIG REQUIRED COMPONENTS filesystem locale regex)
 # https://cmake.org/cmake/help/v3.12/module/FindZLIB.html
 find_package(ZLIB REQUIRED)
 # https://cmake.org/cmake/help/v3.12/module/FindOpenGL.html
@@ -236,7 +241,14 @@ target_link_libraries(
     PRIVATE
     "${RT_LIBRARIES}"
     "${CMAKE_THREAD_LIBS_INIT}"
-    "${Boost_LIBRARIES}"
+    # Link the imported Boost targets directly instead of using
+    # Boost_LIBRARIES.
+    #
+    # The CONFIG package exports these targets, and that is the supported
+    # modern way to express the dependency graph.
+    Boost::filesystem
+    Boost::locale
+    Boost::regex
     "${ZLIB_LIBRARIES}"
     "${OPENGL_LIBRARIES}"
     "${GLEW_LIBRARIES}"
@@ -248,6 +260,13 @@ target_link_libraries(
     "${Vorbis_File_LIBRARY}"
     "${Cairo_LIBRARIES}"
 )
+
+if(TARGET Boost::system)
+    # Some distro/Boost combinations no longer export the system component
+    # target in the old way, so only link it when the config package actually
+    # provides it.
+    target_link_libraries(anura PRIVATE Boost::system)
+endif()
 
 # END Linker config
 


### PR DESCRIPTION
26.06 is out and thus we add it to our smoketest battery.

Boost 1.90 reorganizes things to a point where Ubuntu has dropped a separate `libboost-system-dev` package. The workaround is to move to the `find_package(CONFIG ...)` based mechanism, but this raises the expected floor of Boost to 1.70.

Dropped distro versions (libboost older than 1.70):

* Alma Linux
  * 8
* Rocky Linux
  * 8
* openSUSE Leap
  * 15.4
  * 15.5
  * 15.6
* Fedora
  * 33
  * 34
  * 35
  * 36