### PR TITLE
Actually test all of Rocky 10

### DIFF
--- a/.github/workflows/pr-smoketest-rocky.yaml
+++ b/.github/workflows/pr-smoketest-rocky.yaml
@@ -41,7 +41,7 @@ jobs:
           - rocky: "10"
             compiler: clang++
             build-type: Debug
-          - rocky: "8"
+          - rocky: "10"
             compiler: clang++
             build-type: Release
           # 11 is expected in 2028-05


### PR DESCRIPTION
Seems we had a copy paste mistake in the build matrix so far and one of the Rocky 10 builds was actually a Rocky 8 build.